### PR TITLE
feat: macOS tarball (Apple Silicon) via the shared install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,25 @@ jobs:
       - name: smoke test (fixture-gated half skips without the 3.7 GB model)
         run: make CC=gcc-14 TARGET=linux test
 
+  macos-build:
+    # Apple Silicon only — geistlib's mac targets are cpu_neon.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: deps
+        run: brew install libomp
+      - name: build (static libomp, as the release tarball does)
+        run: make GEIST_STATIC_OMP=1
+      - name: smoke test (fixture-gated half skips without the 3.7 GB model)
+        run: sh tests/smoke.sh
+      - name: tarball builds and the wrapper resolves its prefix
+        run: |
+          sh packaging/build-tarball.sh
+          mkdir -p /tmp/tb && tar -C /tmp/tb -xzf geist-diktat_*_macos-*.tar.gz
+          /tmp/tb/geist-diktat_*/bin/geist-diktat 2>&1 | grep -q usage
+
   nvim-plugin:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,16 @@ jobs:
 
   macos-build:
     # Apple Silicon only — geistlib's mac targets are cpu_neon.
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      # The image default is Xcode 16.4, whose Apple clang only knows
+      # -std=c2x; geistlib builds with -std=c23. Pick the newest Xcode on
+      # the image rather than pinning a version that ages out.
+      - name: select the newest Xcode
+        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
       - name: deps
         run: brew install libomp
       - name: build (static libomp, as the release tarball does)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,45 @@ jobs:
             geist-diktat_*.deb
             geist-diktat_*_linux-*.tar.gz
 
+  macos-tarball:
+    # Apple Silicon only: geistlib's mac targets build the cpu_neon
+    # backend, so there is no Intel Mac build to ship.
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: version from tag
+        id: v
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: deps
+        run: brew install libomp
+      # GEIST_STATIC_OMP=1 is not optional here: without it the binary
+      # hard-links Homebrew's libomp.dylib and the tarball is broken on
+      # any Mac without it. build-tarball.sh fails the build if that
+      # regresses.
+      - name: build (static libomp)
+        run: make GEIST_STATIC_OMP=1
+      - name: smoke test (fixture-gated half skips without the model)
+        run: sh tests/smoke.sh
+      - name: package
+        run: VERSION=${{ steps.v.outputs.version }} sh packaging/build-tarball.sh
+      - name: tarball sanity (wrapper resolves its unpacked prefix)
+        run: |
+          mkdir -p /tmp/tb && tar -C /tmp/tb -xzf geist-diktat_*_macos-*.tar.gz
+          /tmp/tb/geist-diktat_*/bin/geist-diktat 2>&1 | grep -q usage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-arm64
+          path: geist-diktat_*_macos-*.tar.gz
+
   publish:
-    needs: artifacts
+    needs: [artifacts, macos-tarball]
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -92,11 +129,13 @@ jobs:
           for a in amd64 arm64; do
             cp geist-diktat_*_"$a".deb "geist-diktat_$a.deb"
           done
-          for m in x86_64 aarch64; do
-            cp geist-diktat_*_linux-"$m".tar.gz "geist-diktat_linux-$m.tar.gz"
+          # geist-diktat_0.1.3_macos-arm64.tar.gz -> geist-diktat_macos-arm64.tar.gz
+          for f in geist-diktat_*_linux-*.tar.gz geist-diktat_*_macos-*.tar.gz; do
+            [ -e "$f" ] || continue
+            cp "$f" "geist-diktat_${f#geist-diktat_*_}"
           done
       - name: SHA256SUMS (install.sh verifies every asset against it)
-        run: sha256sum geist-diktat_*.deb geist-diktat_*linux-*.tar.gz > SHA256SUMS
+        run: sha256sum geist-diktat_*.deb geist-diktat_*.tar.gz > SHA256SUMS
       - name: create release with all artifacts
         env:
           GH_TOKEN: ${{ github.token }}
@@ -105,4 +144,4 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            geist-diktat_*.deb geist-diktat_*linux-*.tar.gz SHA256SUMS
+            geist-diktat_*.deb geist-diktat_*.tar.gz SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
   macos-tarball:
     # Apple Silicon only: geistlib's mac targets build the cpu_neon
     # backend, so there is no Intel Mac build to ship.
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,6 +95,11 @@ jobs:
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
+      # The image default is Xcode 16.4, whose Apple clang only knows
+      # -std=c2x; geistlib builds with -std=c23. Pick the newest Xcode on
+      # the image rather than pinning a version that ages out.
+      - name: select the newest Xcode
+        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
       - name: deps
         run: brew install libomp
       # GEIST_STATIC_OMP=1 is not optional here: without it the binary

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ geist-diktat setup                 # per-user model download (~3.7 GB, SHA-pinne
 Non-Debian distros: grab the `linux-{x86_64,aarch64}.tar.gz` from the
 same release — unpack anywhere, `bin/geist-diktat` works in place.
 
+## macOS (Apple Silicon)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/geisten/geist-diktat/main/install.sh | sh
+brew install sox        # mic capture; ffmpeg works too
+geist-diktat setup      # model (~3.7 GB, SHA-pinned)
+geist-diktat run        # transcript lines on stdout
+```
+
+The core is the same engine and the same model. What macOS does **not**
+get is the typing path: there is no IBus, so `run` gives you the
+transcript stream to pipe wherever you want. `GEIST_DIKTAT_CAPTURE`
+overrides the capture command when the default mic is not the right one.
+
+Intel Macs are not built — geistlib's mac target compiles the `cpu_neon`
+backend. Build from source with a scalar backend if you need one.
+
 Then dictate: run `ibus restart`, add the input source *geist-diktat
 (Diktat)* (GNOME Settings → Keyboard → Input Sources, listed under
 German), and switch to it with `Super+Space`. Selecting the source starts

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 #
 # Debian/Ubuntu: downloads the latest release .deb for this architecture
 # and installs it via apt (the only sudo step, announced first).
-# Other distros: unpacks the static tarball to ~/.local/geist-diktat.
+# Other distros and macOS: unpacks the tarball to ~/.local/geist-diktat.
 set -eu
 
 REPO="geisten/geist-diktat"
@@ -21,10 +21,20 @@ aarch64 | arm64) DEB_ARCH=arm64 ;;
     ;;
 esac
 
-[ "$(uname -s)" = Linux ] || {
-    echo "geist-diktat: Linux only (got $(uname -s)) — build from source on other systems" >&2
+case "$(uname -s)" in
+Linux)  OS=linux ;;
+Darwin) OS=macos ;;
+*)
+    echo "geist-diktat: Linux and macOS only (got $(uname -s)) — build from source" >&2
     exit 1
-}
+    ;;
+esac
+
+if [ "$OS" = macos ] && [ "$(uname -m)" != arm64 ]; then
+    echo "geist-diktat: macOS builds are Apple Silicon only (got $(uname -m))" >&2
+    echo "(the engine's mac target builds the cpu_neon backend)" >&2
+    exit 1
+fi
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
@@ -68,9 +78,9 @@ if command -v apt-get >/dev/null 2>&1; then
         sudo apt-get install -y "$TMP/$DEB"
     fi
 else
-    TAR="geist-diktat_linux-$(uname -m).tar.gz"
+    TAR="geist-diktat_${OS}-$(uname -m).tar.gz"
     DEST="$HOME/.local/geist-diktat"
-    echo "no apt found — unpacking the static tarball to $DEST ..."
+    echo "no apt found — unpacking the $OS tarball to $DEST ..."
     curl -fL --retry 3 -o "$TMP/$TAR" "$BASE/$TAR"
     verify "$TMP/$TAR" "$TAR"
     rm -rf "$DEST"
@@ -79,10 +89,16 @@ else
     echo "add to PATH: export PATH=\"$DEST/bin:\$PATH\""
 fi
 
-cat <<'EOF'
-
-Next steps:
-  geist-diktat setup    # model download (~3.7 GB, SHA-pinned)
-  ibus restart          # then add the input source "geist-diktat (Diktat)"
-                        # under Settings -> Keyboard (listed under German)
-EOF
+echo
+echo "Next steps:"
+echo "  geist-diktat setup    # model download (~3.7 GB, SHA-pinned)"
+if [ "$OS" = macos ]; then
+    echo "  brew install sox      # mic capture (ffmpeg also works)"
+    echo "  geist-diktat run      # transcript lines on stdout"
+    echo
+    echo "No IBus on macOS: 'run' gives you the transcript stream to pipe;"
+    echo "there is no typing-into-the-focused-app path here."
+else
+    echo "  ibus restart          # then add the input source \"geist-diktat (Diktat)\""
+    echo "                        # under Settings -> Keyboard (listed under German)"
+fi

--- a/packaging/build-tarball.sh
+++ b/packaging/build-tarball.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
-# build-tarball.sh — static tarball for non-Debian distros.
+# build-tarball.sh — tarball for non-Debian distros and for macOS.
 #
-#   make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native
-#   sh packaging/build-tarball.sh    # -> geist-diktat_<v>_linux-<arch>.tar.gz
+#   make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native   # linux
+#   make GEIST_STATIC_OMP=1                            # macOS (arm64 only)
+#
+# macOS needs GEIST_STATIC_OMP=1: without it the binary hard-links
+# /opt/homebrew/opt/libomp/lib/libomp.dylib and the tarball is broken on
+# any Mac that has no Homebrew libomp at that path. Checked below.
+# Apple Silicon only — geistlib's mac targets build cpu_neon, so there
+# is no Intel Mac build.
+#   sh packaging/build-tarball.sh    # -> geist-diktat_<v>_<os>-<arch>.tar.gz
 #
 # The layout mirrors the installed /usr prefix (bin/, share/geist-diktat/),
 # and the wrapper derives its prefix from its own location — the same
@@ -13,7 +20,11 @@ cd "$(dirname "$0")/.."
 
 VERSION="${VERSION:-0.1.0}"
 ARCH="$(uname -m)"
-NAME="geist-diktat_${VERSION}_linux-${ARCH}"
+case "$(uname -s)" in
+Darwin) OS=macos ;;
+*)      OS=linux ;;
+esac
+NAME="geist-diktat_${VERSION}_${OS}-${ARCH}"
 STAGE="build/$NAME"
 
 test -x ./diktat || { echo "build ./diktat first (make)" >&2; exit 1; }
@@ -21,11 +32,20 @@ test -x ./diktat || { echo "build ./diktat first (make)" >&2; exit 1; }
 rm -rf "$STAGE"
 mkdir -p "$STAGE/bin" "$STAGE/share/geist-diktat"
 install -m755 diktat "$STAGE/bin/diktat"
-strip "$STAGE/bin/diktat" 2>/dev/null || true
+strip "$STAGE/bin/diktat" 2>/dev/null || true   # advisory: BSD strip is pickier
 install -m755 packaging/geist-diktat "$STAGE/bin/geist-diktat"
 install -m644 geistlib/audio_test_data/mel_constants.bin "$STAGE/share/geist-diktat/"
 install -m755 geistlib/tools/fetch_audio_tower.py "$STAGE/share/geist-diktat/"
 install -m644 README.md LICENSE "$STAGE/"
+
+# A shipped macOS binary must reach no further than the system
+# frameworks, which are present on every Mac.
+if [ "$OS" = macos ] &&
+    otool -L "$STAGE/bin/diktat" | tail -n +2 | grep -qvE '/usr/lib/|/System/Library/'; then
+    echo "diktat links a non-system library — rebuild with GEIST_STATIC_OMP=1" >&2
+    otool -L "$STAGE/bin/diktat" | tail -n +2 >&2
+    exit 1
+fi
 
 tar -C build -czf "$NAME.tar.gz" "$NAME"
 echo "built: $NAME.tar.gz"

--- a/packaging/geist-diktat
+++ b/packaging/geist-diktat
@@ -4,9 +4,14 @@
 #   geist-diktat setup    fetch model + tower into ~/.local/share
 #   geist-diktat run      mic -> transcript lines on stdout
 #
-# Typing into the focused window is the IBus input source
+# Linux: typing into the focused window is the IBus input source
 # "geist-diktat (Diktat)" (Settings -> Keyboard -> Input Sources); this
 # wrapper only provisions the model and offers the raw stdout pipeline.
+# macOS: the tarball ships the same core, but there is no IBus — `run`
+# gives you transcript lines to pipe wherever you want.
+#
+# The data dir stays ~/.local/share on both: one path, and the model is
+# not something macOS wants in ~/Library either way.
 set -e
 
 # Prefix from our own location: /usr when installed (/usr/bin/geist-diktat),
@@ -25,6 +30,36 @@ TOWER_SHA=d6c45a6c276212dc3a793e66dfc588d89c12d1ac92c0e4b85494390ca848cd77
 export GEIST_AUDIO_MODEL_PATH="${GEIST_AUDIO_MODEL_PATH:-$TOWER}"
 export GEIST_MEL_CONSTANTS_PATH="${GEIST_MEL_CONSTANTS_PATH:-$MEL}"
 
+# Mic capture is the one genuinely platform-specific piece. Neither sox
+# nor ffmpeg ships with macOS, so probe for whichever is installed;
+# GEIST_DIKTAT_CAPTURE overrides the whole command, because the right mic
+# device is machine-specific (an avfoundation index cannot be guessed).
+capture() {
+    if [ -n "${GEIST_DIKTAT_CAPTURE:-}" ]; then
+        eval "exec $GEIST_DIKTAT_CAPTURE"
+    fi
+    case "$(uname -s)" in
+    Darwin)
+        # sox -d is the default input device — no index to guess.
+        if command -v sox >/dev/null; then
+            exec sox -q -d -t raw -r 16000 -e signed -b 16 -c 1 -
+        elif command -v ffmpeg >/dev/null; then
+            exec ffmpeg -loglevel quiet -f avfoundation -i :default \
+                -ar 16000 -ac 1 -f s16le -
+        fi
+        echo "no capture tool — brew install sox (or ffmpeg)" >&2
+        exit 1
+        ;;
+    *)
+        command -v arecord >/dev/null || {
+            echo "arecord not found (apt install alsa-utils)" >&2
+            exit 1
+        }
+        exec arecord -q -f S16_LE -r 16000 -c 1 -t raw
+        ;;
+    esac
+}
+
 sha_ok() { [ "$( (sha256sum "$1" 2>/dev/null || shasum -a 256 "$1") | cut -d' ' -f1)" = "$2" ]; }
 
 setup() {
@@ -42,9 +77,15 @@ setup() {
         echo "downloading audio tower (~590 MB, Range extraction) ..."
         python3 "$PREFIX/share/geist-diktat/fetch_audio_tower.py" -o "$TOWER" --sha256 "$TOWER_SHA"
     fi
-    command -v arecord >/dev/null || echo "NOTE: arecord missing (apt install alsa-utils)"
-    echo "setup complete — run 'ibus restart', then add the input source"
-    echo "'geist-diktat (Diktat)' under Settings -> Keyboard."
+    if [ "$(uname -s)" = Darwin ]; then
+        command -v sox >/dev/null || command -v ffmpeg >/dev/null ||
+            echo "NOTE: no capture tool (brew install sox)"
+        echo "setup complete — 'geist-diktat run' prints transcript lines."
+    else
+        command -v arecord >/dev/null || echo "NOTE: arecord missing (apt install alsa-utils)"
+        echo "setup complete — run 'ibus restart', then add the input source"
+        echo "'geist-diktat (Diktat)' under Settings -> Keyboard."
+    fi
 }
 
 case "$1" in
@@ -52,7 +93,7 @@ setup) setup ;;
 run)
     shift
     [ -f "$MODEL" ] || { echo "model missing — run: geist-diktat setup" >&2; exit 1; }
-    arecord -q -f S16_LE -r 16000 -c 1 -t raw | exec "$PREFIX/bin/diktat" "$MODEL" "$@"
+    capture | exec "$PREFIX/bin/diktat" "$MODEL" "$@"
     ;;
 *)
     echo "usage: geist-diktat setup | run [rms-threshold]" >&2


### PR DESCRIPTION
> **Stapelt auf #9** — Base ist `claude/ponytail-audit-ede612`, weil dieselben Dateien angefasst werden. Nach dem Merge von #9 auf `main` umstellen.

`install.sh` hatte ein hartes `[ "$(uname -s)" = Linux ]`-Gate. Die Engine baut längst auf macOS — geistlib hat `mac`/`mac-omp`-Targets und ein Metal-Backend — Linux-spezifisch waren nur die **beiden Enden der Pipe**.

## Aufnahme

`arecord` ist ALSA. Der Wrapper wählt jetzt pro Plattform: bevorzugt `sox` (dessen `-d` ist das Default-Eingabegerät, kein Index zu raten), sonst `ffmpeg` mit avfoundation. Keines von beiden liegt macOS bei, das sagt `setup` auch.

`GEIST_DIKTAT_CAPTURE` überschreibt das Kommando komplett — welches Mikrofon das richtige ist, ist maschinenspezifisch und nicht erratbar.

## Tippen

Es gibt kein IBus auf macOS. `run` liefert den Transkript-Stream, und README wie `install.sh` sagen ausdrücklich, dass der Weg „in die fokussierte App tippen" Linux-only ist. Nichts wird vorgetäuscht.

## `GEIST_STATIC_OMP=1` ist Pflicht

Gemessen, nicht vermutet:

```
ohne:  /System/.../Accelerate
       /opt/homebrew/opt/libomp/lib/libomp.dylib   <- kaputt beim Nutzer
       /usr/lib/libSystem.B.dylib
mit:   /System/.../Accelerate
       /usr/lib/libSystem.B.dylib
```

Ein ohne das Flag gebauter Tarball ist auf jedem Mac ohne Homebrew-libomp an genau diesem Pfad unbrauchbar. `build-tarball.sh` bricht deshalb ab, wenn eine Nicht-System-Bibliothek zurückkommt — **in beide Richtungen getestet**: geht mit dem statischen Binary durch, scheitert mit Exit 1 und Auflistung beim dynamischen.

## Nur Apple Silicon

geistlib setzt in beiden mac-Targets `BACKENDS ?= cpu_neon cpu_scalar` — es gibt keinen Intel-Build. `install.sh` sagt das direkt, statt auf einem nie veröffentlichten Tarball zu 404en.

## Release + CI

`geist-diktat_macos-arm64.tar.gz` wird neben den Linux-Assets publiziert und von derselben `SHA256SUMS` abgedeckt. Die Alias-Schleife leitet Namen jetzt aus den versionierten Dateien ab, statt Arch-Listen hart zu kodieren — lokal gegen genau die Namen getestet, die `install.sh` konstruiert:

```
✓ geist-diktat_linux-x86_64.tar.gz
✓ geist-diktat_linux-aarch64.tar.gz
✓ geist-diktat_macos-arm64.tar.gz
```

Ein `macos-14`-CI-Job baut, smoke-testet und packt den Tarball, damit der Pfad nicht verrottet.

## Verifikation auf einem M-Mac

Tarball baut und packt aus · Wrapper löst sein Prefix auf (`usage`) · `run` ohne Modell meldet sauber · Capture-Override erreicht `diktat` durch die Pipe (`eval`+`exec` getestet) · ffmpeg wird gewählt, wenn sox fehlt · Guard in beide Richtungen · `smoke.sh` und `nvim_smoke.sh` grün · alle Skripte `sh -n`.

**Nicht lokal prüfbar:** der `macos-14`-Runner selbst und der Release-Job — erst die CI dieses PRs zeigt beide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)