### PR TITLE
feat: pin the engine by ref in the Makefile, drop the git submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: deps
         run: sudo apt-get update -q && sudo apt-get install -y -q libopenblas-dev gcc-14
       - name: build
@@ -34,8 +32,6 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       # The image default is Xcode 16.4, whose Apple clang only knows
       # -std=c2x; geistlib builds with -std=c23. Pick the newest Xcode on
       # the image rather than pinning a version that ages out.
@@ -66,8 +62,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: deps
         run: sudo apt-get update -q && sudo apt-get install -y -q gcc-14 libibus-1.0-dev ibus dbus
       - name: build engine + test client
@@ -101,8 +95,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: deps
         run: sudo apt-get update -q && sudo apt-get install -y -q lintian
       # arm64 builds in debian:12 with clang-19: the Pi world runs RasPiOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,10 @@ jobs:
             docker run --rm -v "$PWD:/w" -w /w debian:12 bash -ec '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update -q >/dev/null
-              apt-get install -y -q clang-19 libomp-19-dev libibus-1.0-dev make pkg-config >/dev/null
+              # git + ca-certificates: the engine is cloned by the build itself
+              # now (GEIST_REF), and this build runs inside the container.
+              apt-get install -y -q clang-19 libomp-19-dev libibus-1.0-dev make pkg-config \
+                                    git ca-certificates >/dev/null
               make CC=clang-19 TARGET=linux GEMM_PROVIDER=native
               make CC=clang-19 GEMM_PROVIDER=native ibus-engine-geist-diktat
             '

--- a/.github/workflows/desktop-e2e.yml
+++ b/.github/workflows/desktop-e2e.yml
@@ -20,8 +20,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: build diktat (host) + ibus binaries (container — dev headers without sudo)
         run: |
           make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: [self-hosted, amd-desktop]
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: fetch model + tower (idempotent, SHA-gated)
         run: |
           DATA="$HOME/.local/share/geist-diktat"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: [self-hosted, amd-desktop]
     steps:
       - uses: actions/checkout@v4
+      # Build first: the tower fetcher below lives in geistlib/tools/, and the
+      # engine checkout is created by make (GEIST_REF), no longer by a submodule.
+      - name: build (also clones the pinned engine)
+        run: make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native
       - name: fetch model + tower (idempotent, SHA-gated)
         run: |
           DATA="$HOME/.local/share/geist-diktat"
@@ -30,7 +34,5 @@ jobs:
           fi
           python3 geistlib/tools/fetch_audio_tower.py -o "$DATA/audio_tower.safetensors" \
             --sha256 d6c45a6c276212dc3a793e66dfc588d89c12d1ac92c0e4b85494390ca848cd77
-      - name: build
-        run: make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native
       - name: e2e — transcribe the LibriSpeech fixture, gate on WER
         run: sh tests/e2e_wer.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: version from tag
         id: v
         run: |
@@ -85,8 +83,6 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: version from tag
         id: v
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,10 @@ jobs:
             docker run --rm -v "$PWD:/w" -w /w debian:12 bash -ec '
               export DEBIAN_FRONTEND=noninteractive
               apt-get update -q >/dev/null
-              apt-get install -y -q clang-19 libomp-19-dev libibus-1.0-dev make pkg-config >/dev/null
+              # git + ca-certificates: the engine is cloned by the build itself
+              # now (GEIST_REF), and this build runs inside the container.
+              apt-get install -y -q clang-19 libomp-19-dev libibus-1.0-dev make pkg-config \
+                                    git ca-certificates >/dev/null
               make CC=clang-19 TARGET=linux GEMM_PROVIDER=native
               make CC=clang-19 GEMM_PROVIDER=native ibus-engine-geist-diktat
             '

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /diktat
+/geistlib/
 /ibus-engine-geist-diktat
 /ibus-engine-geist-diktat-test
 /ibus-test-client

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "geistlib"]
-	path = geistlib
-	url = https://github.com/geisten/geistlib

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,12 @@ MODE       ?= release
 
 # Parse-time, not a target: the include directives and detect-target.sh below
 # are evaluated while make is still reading this file. Skipped for goals that
-# do not need an engine, so a fresh `make clean` does not clone 14 MB.
-ifneq (,$(filter-out clean distclean help,$(or $(MAKECMDGOALS),all)))
+# do not need an engine, so a fresh `make clean` does not clone 14 MB and an
+# ibus-only build needs no git in its container.
+# The ibus binaries compile against libibus only — no libgeist, no engine.
+NO_ENGINE := clean distclean help ibus ibus-engine-geist-diktat \
+             ibus-engine-geist-diktat-test ibus-test-client
+ifneq (,$(filter-out $(NO_ENGINE),$(or $(MAKECMDGOALS),all)))
 
 ENGINE := $(shell GEIST_REPO='$(GEIST_REPO)' GEIST_REF='$(GEIST_REF)' \
                   GEISTLIB='$(GEISTLIB)' sh scripts/sync-engine.sh >&2 && echo ok)

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,42 @@
 # geist-diktat — system-wide local dictation on the geist engine.
 #
-# geistlib is a pinned submodule; this Makefile mirrors geistlib's own
-# examples/Makefile so diktat links with exactly the flags the engine
-# was built with — no duplicated platform knowledge.
+# The engine is pinned by GEIST_REF below and checked out into $(GEISTLIB) by
+# scripts/sync-engine.sh — no git submodule. Every make run verifies the
+# checkout against the pin, so bumping GEIST_REF takes effect on the next
+# build; there is no second command to remember and no stale-engine window.
 #
-#   make            # build ./diktat (builds the pinned libgeist.a on demand)
-#   make setup      # fetch model (~3.1 GB) + audio tower (~590 MB), SHA-pinned
-#   make test       # smoke test (full transcript check when fixtures exist)
+# Platform knowledge stays in geistlib: its detect-target.sh picks the target
+# and its mk/ fragments supply the flags, so diktat links with exactly what the
+# engine was built with.
+#
+#   make               # build ./diktat (syncs + builds libgeist.a on demand)
+#   make setup         # fetch model (~3.1 GB) + audio tower (~590 MB), SHA-pinned
+#   make test          # smoke test (full transcript check when fixtures exist)
+#   make GEIST_REF=... # build against another engine revision, one-off
 
-GEISTLIB := geistlib
+GEIST_REPO ?= https://github.com/geisten/geistlib.git
+GEIST_REF  ?= bb751c596f7d6ed3f73fa2d4c4e29e617cada57f
+GEISTLIB   ?= geistlib
+MODE       ?= release
+
+# Parse-time, not a target: the include directives and detect-target.sh below
+# are evaluated while make is still reading this file. Skipped for goals that
+# do not need an engine, so a fresh `make clean` does not clone 14 MB.
+ifneq (,$(filter-out clean distclean help,$(or $(MAKECMDGOALS),all)))
+
+ENGINE := $(shell GEIST_REPO='$(GEIST_REPO)' GEIST_REF='$(GEIST_REF)' \
+                  GEISTLIB='$(GEISTLIB)' sh scripts/sync-engine.sh >&2 && echo ok)
+ifneq ($(ENGINE),ok)
+$(error engine sync failed — see the messages above)
+endif
+
 TARGET ?= $(shell $(GEISTLIB)/mk/detect-target.sh)
-MODE   ?= release
-
 include $(GEISTLIB)/mk/target-$(TARGET).mk
 
 GEMM_PROVIDER ?= native
 include $(GEISTLIB)/mk/gemm-$(GEMM_PROVIDER).mk
+
+endif
 
 LIB := $(GEISTLIB)/lib/$(TARGET)/$(MODE)/libgeist.a
 
@@ -24,7 +45,7 @@ LDFLAGS := $(LDFLAGS_TARGET)
 LDLIBS  := $(LDLIBS_TARGET) $(GEMM_LDLIBS)
 
 
-.PHONY: all setup test ibus clean
+.PHONY: all setup test ibus clean distclean
 
 all: diktat
 
@@ -69,3 +90,8 @@ test: diktat
 
 clean:
 	rm -f diktat ibus-engine-geist-diktat ibus-engine-geist-diktat-test ibus-test-client
+
+# The engine checkout is build input, not source: distclean drops it so the
+# next build re-clones at the pin.
+distclean: clean
+	rm -rf $(GEISTLIB)

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ lines on stdout; compose them as in the snippet above.
 ## Build from source
 
 ```sh
-git clone --recurse-submodules https://github.com/geisten/geist-diktat
+git clone https://github.com/geisten/geist-diktat
 cd geist-diktat
-make                    # builds diktat against the pinned geistlib
+make                    # clones + builds the pinned geistlib, then diktat
 make setup              # model (~3.1 GB) + audio tower (~590 MB), SHA-pinned
 arecord -q -f S16_LE -r 16000 -c 1 -t raw | \
   ./diktat geistlib/gguf_artifacts/gemma4-e2b-Q4_K_M.gguf   # transcript lines on stdout

--- a/scripts/sync-engine.sh
+++ b/scripts/sync-engine.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# sync-engine.sh — put the pinned geistlib engine at $GEISTLIB.
+#
+# Called from the Makefile while make is still PARSING: the engine's mk/
+# fragments are include'd and its detect-target.sh is invoked there, so the
+# checkout has to be right before parsing ends. A normal target runs too late —
+# make would already have read the previous target-*.mk.
+#
+# Verifies on every run rather than only cloning when missing. A
+# clone-if-missing check leaves the old engine in place after a GEIST_REF bump,
+# and that ships as a binary which builds fine and mis-transcribes — the #277
+# "deaf binary" class — instead of failing the build.
+set -eu
+
+: "${GEIST_REPO:?}" "${GEIST_REF:?}" "${GEISTLIB:?}"
+
+if [ ! -d "$GEISTLIB/.git" ]; then
+    echo "engine: cloning $GEIST_REPO -> $GEISTLIB"
+    rm -rf "$GEISTLIB"
+    git clone --quiet "$GEIST_REPO" "$GEISTLIB"
+fi
+
+# Resolve the pin locally; only reach the network when the ref is unknown.
+want=$(git -C "$GEISTLIB" rev-parse --quiet --verify "$GEIST_REF^{commit}" || true)
+if [ -z "$want" ]; then
+    echo "engine: fetching $GEIST_REF"
+    git -C "$GEISTLIB" fetch --quiet --tags origin
+    want=$(git -C "$GEISTLIB" rev-parse --verify "$GEIST_REF^{commit}")
+fi
+
+if [ "$(git -C "$GEISTLIB" rev-parse HEAD)" != "$want" ]; then
+    echo "engine: $GEIST_REF -> $(echo "$want" | cut -c1-12)"
+    git -C "$GEISTLIB" checkout --quiet --detach "$want"
+fi


### PR DESCRIPTION
Das Submodul hat seinen Pin nur bei explizitem `git submodule update` durchgesetzt. Ein Pull, der den Gitlink verschiebt, ließ das Arbeitsverzeichnis auf der alten Engine stehen — genau das ist uns heute in diesem Repo passiert. Und dieser Fehler liefert ein Binary, das baut und falsch transkribiert, keinen Build-Fehler: die `#277`-Klasse, die im Makefile bereits dokumentiert war.

## Was jetzt gilt

```make
GEIST_REPO ?= https://github.com/geisten/geistlib.git
GEIST_REF  ?= bb751c596f7d6ed3f73fa2d4c4e29e617cada57f
```

`scripts/sync-engine.sh` **verifiziert bei jedem make-Lauf**: klonen, wenn nicht da; fetchen nur, wenn der Ref lokal unbekannt ist; auschecken, wenn HEAD abgedriftet ist. Das Anheben von `GEIST_REF` ist damit die gesamte Operation — kein zweites Kommando, kein Fenster mit veralteter Engine.

Das spiegelt geistshells `GEIST_REPO`/`GEIST_REF`-Muster, **ohne dessen Lücke**: dortiges `sync-engine` prüft nur `if [ ! -d "$GEIST_DIR/.git" ]` und vergleicht den Checkout nie mit dem Pin.

## Warum zur Parse-Zeit

Der Sync läuft nicht als Target, sondern beim Einlesen des Makefiles — er muss:

```make
TARGET ?= $(shell $(GEISTLIB)/mk/detect-target.sh)
include $(GEISTLIB)/mk/target-$(TARGET).mk
```

Beides wertet make aus, *bevor* irgendein Target läuft. Ein normales Target käme zu spät, mit den alten Fragmenten bereits gelesen. geistshell ist über dieselbe Reihenfolge gestolpert (`#105`: „detect-target.sh echoed `mac` when the engine was not cloned yet — so CI built the mac target on Linux").

Übersprungen wird der Hook für `clean`, `distclean` und `help`, damit ein frisches `make clean` nicht 14 MB klont.

## geistlib bleibt die Quelle der Plattformlogik

Nichts davon wird hier nachgebaut: `detect-target.sh` wählt den Target, `mk/target-*.mk` und `mk/gemm-*.mk` liefern die Flags, `make -C $(GEISTLIB) lib` baut das Archiv. Der Checkout-Pfad bleibt `geistlib/` (jetzt gitignoriert), damit Tests, Packaging und CI ihre Pfade behalten. Neu: `make distclean` wirft ihn weg.

## Verifikation auf einem M-Mac

Gegen einen **echten frischen Klon ohne Submodul**, nicht gegen den Arbeitsbaum:

| Test | Ergebnis |
|---|---|
| Klon enthält kein `geistlib/` | ✓ |
| `make` klont, pinnt, baut | ✓ Binary, HEAD == `bb751c596f7d…` exakt |
| `sh tests/smoke.sh` | ✓ |
| `make GEIST_REF=5bb88cba…` | ✓ Engine wandert, Lib wird neu gebaut |
| `make` zurück auf Standard-Pin | ✓ wandert zurück |
| `make clean` auf frischem Klon | ✓ legt kein `geistlib/` an |

## Ein CI-Schritt musste umziehen

`nightly.yml` holte das Audio-Tower über `geistlib/tools/fetch_audio_tower.py` **vor** dem Build. Ohne Submodul existiert der Pfad zu dem Zeitpunkt nicht — der eine Job, der das Modell wirklich testet, wäre an einer fehlenden Datei gestorben. Build läuft jetzt zuerst. Alle anderen `geistlib/`-Zugriffe in CI und Packaging liegen bereits hinter dem Build; geprüft.

`submodules: true` ist aus allen Workflows raus, `--recurse-submodules` aus dem README.

**Nicht lokal prüfbar:** die Linux-Jobs und der `macos-15`-Runner. Der nightly-Lauf ist die eigentliche Abnahme, weil dieser PR den Engine-Bezug anfasst — ich stoße ihn nach dem CI-Durchlauf an.

🤖 Generated with [Claude Code](https://claude.com/claude-code)