### PR TITLE
feat: link the Linux tarball fully static against musl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,36 @@ jobs:
       - name: smoke test (fixture-gated half skips without the 3.7 GB model)
         run: make CC=gcc-14 TARGET=linux test
 
+  musl-tarball:
+    # The Linux tarball is linked fully static against musl, so it must be built
+    # and proven per PR — the release job is not the place to find out that the
+    # one artifact claiming "runs on any distro" does not.
+    strategy:
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      # Alpine 3.21 is what geistlib uses for its own musl-static artifact:
+      # gcc 14 for -std=c23, musl-built libgomp for OpenMP.
+      - name: build + package (alpine 3.21, musl-static)
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w alpine:3.21 sh -ec '
+            apk add --no-cache build-base linux-headers git >/dev/null
+            git config --global --add safe.directory /w
+            make TARGET=linux CC=gcc GEMM_PROVIDER=native EXTRA_LDFLAGS=-static
+            sh packaging/build-tarball.sh
+          '
+      # On the glibc host: a static binary that only runs where it was built
+      # would defeat the point. build-tarball.sh already asserted no dynamic
+      # section; this asserts it actually executes elsewhere.
+      - name: runs on glibc, unpacked
+        run: |
+          mkdir -p /tmp/tb && tar -C /tmp/tb -xzf geist-diktat_*_linux-*.tar.gz
+          /tmp/tb/geist-diktat_*/bin/geist-diktat 2>&1 | grep -q usage
+          /tmp/tb/geist-diktat_*/bin/diktat /nonexistent.gguf </dev/null 2>&1 | grep -q "model_load failed"
+          file /tmp/tb/geist-diktat_*/bin/diktat
+
   macos-build:
     # Apple Silicon only — geistlib's mac targets are cpu_neon.
     runs-on: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,11 @@ jobs:
             make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native
             make CC=gcc-14 GEMM_PROVIDER=native ibus-engine-geist-diktat
           fi
-      - name: package
-        run: |
-          VERSION=${{ steps.v.outputs.version }} sh packaging/build-deb.sh
-          VERSION=${{ steps.v.outputs.version }} sh packaging/build-tarball.sh
+      # .deb only. The tarball is built musl-static in linux-tarball below:
+      # the .deb may depend on the distro's libs (it needs libibus anyway), the
+      # tarball is the "any distro" artifact and must not.
+      - name: package (.deb)
+        run: VERSION=${{ steps.v.outputs.version }} sh packaging/build-deb.sh
       - name: lintian
         run: lintian --fail-on error geist-diktat_*.deb
       - name: install sanity against the release artifact
@@ -66,16 +67,55 @@ jobs:
           geist-diktat 2>&1 | grep -q usage
           diktat /nonexistent.gguf </dev/null 2>&1 | grep -q "model_load failed"
           ls /usr/share/ibus/component/geist-diktat.xml /usr/libexec/ibus-engine-geist-diktat
-      - name: tarball sanity (wrapper resolves its unpacked prefix)
-        run: |
-          mkdir -p /tmp/tb && tar -C /tmp/tb -xzf geist-diktat_*_linux-*.tar.gz
-          /tmp/tb/geist-diktat_*/bin/geist-diktat 2>&1 | grep -q usage
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.arch }}
-          path: |
-            geist-diktat_*.deb
-            geist-diktat_*_linux-*.tar.gz
+          path: geist-diktat_*.deb
+
+  linux-tarball:
+    # Its own job with a fresh checkout, not a step in `artifacts`: geistlib
+    # builds into build/linux/release for glibc and musl alike, so a second
+    # build in the same tree would silently relink glibc objects.
+    strategy:
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: version from tag
+        id: v
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+      # Fully static against musl, not glibc: no libc dependency at all, so the
+      # tarball stops caring which distro it lands on — that is what the .deb's
+      # debian:12-vs-ubuntu build split exists to work around. Alpine 3.21 is
+      # the version geistlib itself uses for this: gcc 14 for -std=c23, plus a
+      # musl-built libgomp for OpenMP. GEMM_PROVIDER=native keeps OpenBLAS out.
+      # -static belongs here, not in geistlib: link flags are the linker's.
+      - name: build + package (alpine 3.21, musl-static)
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w \
+            -e VERSION=${{ steps.v.outputs.version }} alpine:3.21 sh -ec '
+            apk add --no-cache build-base linux-headers git >/dev/null
+            git config --global --add safe.directory /w
+            make TARGET=linux CC=gcc GEMM_PROVIDER=native EXTRA_LDFLAGS=-static
+            sh packaging/build-tarball.sh
+          '
+      # Unpacked on the glibc host, deliberately: a musl-static binary has to
+      # run somewhere it was not built.
+      - name: tarball sanity on glibc (wrapper + binary both run)
+        run: |
+          mkdir -p /tmp/tb && tar -C /tmp/tb -xzf geist-diktat_*_linux-*.tar.gz
+          /tmp/tb/geist-diktat_*/bin/geist-diktat 2>&1 | grep -q usage
+          /tmp/tb/geist-diktat_*/bin/diktat /nonexistent.gguf </dev/null 2>&1 | grep -q "model_load failed"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-tarball-${{ matrix.runner }}
+          path: geist-diktat_*_linux-*.tar.gz
 
   macos-tarball:
     # Apple Silicon only: geistlib's mac targets build the cpu_neon
@@ -118,7 +158,7 @@ jobs:
           path: geist-diktat_*_macos-*.tar.gz
 
   publish:
-    needs: [artifacts, macos-tarball]
+    needs: [artifacts, linux-tarball, macos-tarball]
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,16 @@ endif
 
 LIB := $(GEISTLIB)/lib/$(TARGET)/$(MODE)/libgeist.a
 
-CFLAGS  := -std=c23 -O2 -Wall -Wextra -I$(GEISTLIB)/include $(CFLAGS_TARGET) $(GEMM_CFLAGS)
-LDFLAGS := $(LDFLAGS_TARGET)
-LDLIBS  := $(LDLIBS_TARGET) $(GEMM_LDLIBS)
+# EXTRA_* are geistlib's own escape hatches (mk/common.mk); same names here so
+# one convention covers both. The Linux release tarball links with
+# EXTRA_LDFLAGS=-static against musl — geistlib deliberately keeps -static out
+# of its archive build, because link flags belong to whoever links.
+CFLAGS  := -std=c23 -O2 -Wall -Wextra -I$(GEISTLIB)/include $(CFLAGS_TARGET) $(GEMM_CFLAGS) $(EXTRA_CFLAGS)
+LDFLAGS := $(LDFLAGS_TARGET) $(EXTRA_LDFLAGS)
+LDLIBS  := $(LDLIBS_TARGET) $(GEMM_LDLIBS) $(EXTRA_LDLIBS)
 
 
-.PHONY: all setup test ibus clean distclean
+.PHONY: all setup test test-audit ibus clean distclean
 
 all: diktat
 
@@ -87,6 +91,10 @@ setup:
 
 test: diktat
 	sh tests/smoke.sh
+
+# Detailed model-free contracts; exposes the findings in doc/AUDIT-2026-09-05.md.
+test-audit:
+	CC="$(CC)" python3 -m unittest discover -s tests -p 'test_*.py' -v
 
 clean:
 	rm -f diktat ibus-engine-geist-diktat ibus-engine-geist-diktat-test ibus-test-client

--- a/packaging/build-tarball.sh
+++ b/packaging/build-tarball.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # build-tarball.sh — tarball for non-Debian distros and for macOS.
 #
-#   make CC=gcc-14 TARGET=linux GEMM_PROVIDER=native   # linux
+#   make TARGET=linux GEMM_PROVIDER=native EXTRA_LDFLAGS=-static   # linux, on musl
 #   make GEIST_STATIC_OMP=1                            # macOS (arm64 only)
 #
 # macOS needs GEIST_STATIC_OMP=1: without it the binary hard-links
@@ -38,14 +38,27 @@ install -m644 geistlib/audio_test_data/mel_constants.bin "$STAGE/share/geist-dik
 install -m755 geistlib/tools/fetch_audio_tower.py "$STAGE/share/geist-diktat/"
 install -m644 README.md LICENSE "$STAGE/"
 
-# A shipped macOS binary must reach no further than the system
-# frameworks, which are present on every Mac.
-if [ "$OS" = macos ] &&
-    otool -L "$STAGE/bin/diktat" | tail -n +2 | grep -qvE '/usr/lib/|/System/Library/'; then
-    echo "diktat links a non-system library — rebuild with GEIST_STATIC_OMP=1" >&2
-    otool -L "$STAGE/bin/diktat" | tail -n +2 >&2
-    exit 1
-fi
+# A shipped binary must not reach past what the platform guarantees.
+# macOS: the system frameworks, present on every Mac. Linux: nothing at all —
+# the tarball is the "runs on any distro" artifact, so it is linked static
+# against musl and must carry no dynamic section. readelf, not ldd: musl and
+# glibc word their ldd output differently, the ELF header does not.
+case "$OS" in
+macos)
+    if otool -L "$STAGE/bin/diktat" | tail -n +2 | grep -qvE '/usr/lib/|/System/Library/'; then
+        echo "diktat links a non-system library — rebuild with GEIST_STATIC_OMP=1" >&2
+        otool -L "$STAGE/bin/diktat" | tail -n +2 >&2
+        exit 1
+    fi
+    ;;
+linux)
+    if ! readelf -d "$STAGE/bin/diktat" 2>/dev/null | grep -q "There is no dynamic section"; then
+        echo "diktat is not statically linked — build it on musl with EXTRA_LDFLAGS=-static" >&2
+        readelf -d "$STAGE/bin/diktat" 2>&1 | head -20 >&2
+        exit 1
+    fi
+    ;;
+esac
 
 tar -C build -czf "$NAME.tar.gz" "$NAME"
 echo "built: $NAME.tar.gz"


### PR DESCRIPTION
> **Stapelt auf #12.** Base ist `claude/engine-pin-via-make`; nach dessen Merge auf `main` umhängen.

Der Tarball ist das „läuft auf jeder Distro"-Artefakt — war aber ein glibc-Binary und hat damit jede glibc-Frage geerbt, die auch das `.deb` hat: ubuntu-24.04-Builds ziehen `GLIBC_2.38+` und `libmvec` und sterben auf RasPiOS bookworm. Genau deshalb existiert der debian:12-Umweg. **Ein musl-statisches Binary hat gar keine libc-Abhängigkeit, damit stellt sich die Frage nicht mehr.**

## Rezept übernommen, nicht erfunden

geistlib baut sein eigenes musl-static-Artefakt bereits so, und ich habe dessen Job als Vorlage genommen:

- `alpine:3.21` — gcc 14 für `-std=c23`, dazu ein musl-gebautes libgomp für OpenMP
- `apk add build-base linux-headers`
- `GEMM_PROVIDER=native` hält OpenBLAS aus dem Link
- `-D_GNU_SOURCE` steckt schon in geistlibs `target-linux.mk`, weil `-std=c23` unter musl sonst `strdup` versteckt

`-static` wird **hier** gesetzt, nicht dort — aus dem Grund, den geistlib selbst notiert: *„link flags like -static belong to whoever links it, not to building an archive."*

`EXTRA_CFLAGS` / `EXTRA_LDFLAGS` / `EXTRA_LDLIBS` übernehmen die Namen aus geistlibs `mk/common.mk`, damit es eine Konvention gibt statt einer zweiten.

## Eigener Job, nicht noch ein Schritt

geistlib baut für glibc **und** musl nach `build/linux/release`. Ein zweiter Build im selben Baum würde stillschweigend glibc-Objekte weiterverwenden — deshalb ein eigener Job mit frischem Checkout, so wie geistlib es auch macht.

## Der Guard wird plattformabhängig

`build-tarball.sh` prüft jetzt pro Plattform, dass das Binary nicht weiter greift als die Plattform garantiert:

- **macOS:** nur Systemframeworks (unverändert)
- **Linux:** überhaupt kein dynamischer Abschnitt

`readelf`, nicht `ldd`: musl und glibc formulieren die ldd-Ausgabe unterschiedlich, der ELF-Header nicht.

CI prüft das pro PR auf beiden Arches und packt das Ergebnis **auf dem glibc-Host** aus — ein statisches Binary, das nur dort läuft, wo es gebaut wurde, beweist nichts.

## Das `.deb` bleibt unangetastet

Es braucht `libibus` und die Distro-Bibliotheken per Design. Der debian:12-Umweg bleibt dort, wo er hingehört; er verschwindet nur aus dem Tarball-Pfad.

## Verifikation

**Lokal nicht möglich** — auf diesem Mac läuft kein Docker, und das ist ein Linux-Container-Build. Die CI dieses PRs ist die Prüfung; sie baut auf amd64 und arm64, lässt `build-tarball.sh` die Statik behaupten und führt das Binary dann außerhalb des Containers aus. Fällt einer der beiden Jobs, melde ich das mit dem Log, statt es zu übergehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)