### PR TITLE
ci: pin Xcode instead of following whatever the image ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,23 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      # The image default is Xcode 16.4, whose Apple clang only knows
-      # -std=c2x; geistlib builds with -std=c23. Pick the newest Xcode on
-      # the image rather than pinning a version that ages out.
-      - name: select the newest Xcode
-        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
+      # The image default is Xcode 16.4, whose Apple clang only knows -std=c2x
+      # while geistlib builds with -std=c23 — that cost a red job once already.
+      # Pinned rather than "newest on the image": newest would just as readily
+      # hand us a beta, and a toolchain that changes under the build is the
+      # same class of problem as an engine pin that is not enforced. When the
+      # image drops this version the job stops with the list of what it does
+      # have, so the bump is a decision instead of a surprise.
+      - name: select the pinned Xcode
+        run: |
+          XCODE=/Applications/Xcode_26.3.app
+          [ -d "$XCODE" ] || {
+            echo "pinned $XCODE is gone from this image; available:" >&2
+            ls -d /Applications/Xcode_*.app >&2
+            exit 1
+          }
+          sudo xcode-select -s "$XCODE"
+          cc --version | head -1   # recorded in the log: what actually built
       - name: deps
         run: brew install libomp
       - name: build (static libomp, as the release tarball does)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,11 +134,23 @@ jobs:
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
-      # The image default is Xcode 16.4, whose Apple clang only knows
-      # -std=c2x; geistlib builds with -std=c23. Pick the newest Xcode on
-      # the image rather than pinning a version that ages out.
-      - name: select the newest Xcode
-        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
+      # The image default is Xcode 16.4, whose Apple clang only knows -std=c2x
+      # while geistlib builds with -std=c23 — that cost a red job once already.
+      # Pinned rather than "newest on the image": newest would just as readily
+      # hand us a beta, and a toolchain that changes under the build is the
+      # same class of problem as an engine pin that is not enforced. When the
+      # image drops this version the job stops with the list of what it does
+      # have, so the bump is a decision instead of a surprise.
+      - name: select the pinned Xcode
+        run: |
+          XCODE=/Applications/Xcode_26.3.app
+          [ -d "$XCODE" ] || {
+            echo "pinned $XCODE is gone from this image; available:" >&2
+            ls -d /Applications/Xcode_*.app >&2
+            exit 1
+          }
+          sudo xcode-select -s "$XCODE"
+          cc --version | head -1   # recorded in the log: what actually built
       - name: deps
         run: brew install libomp
       # GEIST_STATIC_OMP=1 is not optional here: without it the binary


### PR DESCRIPTION
Von den vier Toolchains, die die CI auswählt, sind **drei bereits gepinnt** — auf der Granularität, die zählt:

| Toolchain | Festlegung | erfüllt `-std=c23` |
|---|---|---|
| `gcc-14` | namentlich | ✓ |
| `clang-19` | namentlich | ✓ |
| `alpine:3.21` | Minor-Tag | ✓ (gcc 14) |
| `debian:12` | Major-Tag | ✓ (via clang-19) |
| **Xcode** | **`sort -V \| tail -1`** | **folgt dem Image** |

Xcode war der Ausreißer. Die Zeile war eine Reaktion auf einen echten Fehlschlag — der macos-14-Default kannte nur `-std=c2x` und libgeist starb an seinem ersten Objekt — aber **„das neueste" ist kein Pin**: Es nimmt genauso bereitwillig eine Beta. Eine Toolchain, die sich unter dem Build ändert, ist dieselbe Fehlerklasse wie ein Engine-Pin, den niemand durchsetzt; die haben wir gerade erst beseitigt.

## Was sich ändert

```yaml
XCODE=/Applications/Xcode_26.3.app
[ -d "$XCODE" ] || {
  echo "pinned $XCODE is gone from this image; available:" >&2
  ls -d /Applications/Xcode_*.app >&2
  exit 1
}
sudo xcode-select -s "$XCODE"
cc --version | head -1
```

`Xcode_26.3` ist die Version, mit der die letzten grünen macOS-Läufe tatsächlich gebaut haben. Verschwindet sie aus dem Image, **bricht der Job ab und listet, was da ist** — der Bump wird eine Entscheidung statt einer Überraschung. `cc --version` landet im Log, damit der Build festhält, welcher Compiler ihn erzeugt hat.

## Was ich bewusst nicht gepinnt habe

**apt-Patch-Versionen.** `gcc-14=14.2.0-4ubuntu2` bricht in dem Moment, in dem Ubuntu sie ablöst, und bringt nichts, was die Major-Version nicht schon liefert. Das wäre Pinnen um des Pinnens willen.

**Container-Digests.** `alpine@sha256:…` statt `alpine:3.21` wäre die stärkere Form und die konsequente Fortsetzung des `GEIST_REF`-Arguments — aber sie schneidet auch die Sicherheitsupdates ab und verlangt manuelle Bumps. Das ist eine Abwägung, die dir gehört, nicht mir; sag Bescheid, wenn du sie willst.

## Verifikation

Die Guard-Logik lokal in beide Richtungen geprüft: existierender Pfad → wird ausgewählt, fehlender → Abbruch. Ob `Xcode_26.3` auf dem `macos-15`-Image liegt, beweist der `macos-build`-Job dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)