### PR TITLE
fix: three destructive-failure paths found by the audit suite

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,9 +83,15 @@ else
     echo "no apt found — unpacking the $OS tarball to $DEST ..."
     curl -fL --retry 3 -o "$TMP/$TAR" "$BASE/$TAR"
     verify "$TMP/$TAR" "$TAR"
-    rm -rf "$DEST"
-    mkdir -p "$DEST"
-    tar -C "$DEST" --strip-components=1 -xzf "$TMP/$TAR"
+    # Unpack first, swap second: extracting over a wiped $DEST left the
+    # user with no installation at all whenever tar failed (bad download,
+    # full disk). $TMP is on the same filesystem only by luck, so copy
+    # into place rather than rename, but not before tar has succeeded.
+    mkdir -p "$TMP/new"
+    tar -C "$TMP/new" --strip-components=1 -xzf "$TMP/$TAR"
+    mkdir -p "$DEST"          # creates the parent dirs...
+    rm -rf "$DEST"            # ...but $DEST itself is the tree we replace
+    mv "$TMP/new" "$DEST"
     echo "add to PATH: export PATH=\"$DEST/bin:\$PATH\""
 fi
 

--- a/packaging/geist-diktat
+++ b/packaging/geist-diktat
@@ -36,15 +36,16 @@ export GEIST_MEL_CONSTANTS_PATH="${GEIST_MEL_CONSTANTS_PATH:-$MEL}"
 # device is machine-specific (an avfoundation index cannot be guessed).
 capture() {
     if [ -n "${GEIST_DIKTAT_CAPTURE:-}" ]; then
-        eval "exec $GEIST_DIKTAT_CAPTURE"
+        eval "$GEIST_DIKTAT_CAPTURE"
+        return
     fi
     case "$(uname -s)" in
     Darwin)
         # sox -d is the default input device — no index to guess.
         if command -v sox >/dev/null; then
-            exec sox -q -d -t raw -r 16000 -e signed -b 16 -c 1 -
+            sox -q -d -t raw -r 16000 -e signed -b 16 -c 1 -
         elif command -v ffmpeg >/dev/null; then
-            exec ffmpeg -loglevel quiet -f avfoundation -i :default \
+            ffmpeg -loglevel quiet -f avfoundation -i :default \
                 -ar 16000 -ac 1 -f s16le -
         fi
         echo "no capture tool — brew install sox (or ffmpeg)" >&2
@@ -55,7 +56,7 @@ capture() {
             echo "arecord not found (apt install alsa-utils)" >&2
             exit 1
         }
-        exec arecord -q -f S16_LE -r 16000 -c 1 -t raw
+        arecord -q -f S16_LE -r 16000 -c 1 -t raw
         ;;
     esac
 }
@@ -93,7 +94,27 @@ setup) setup ;;
 run)
     shift
     [ -f "$MODEL" ] || { echo "model missing — run: geist-diktat setup" >&2; exit 1; }
-    capture | exec "$PREFIX/bin/diktat" "$MODEL" "$@"
+    # A dead mic reaches diktat as EOF and diktat exits 0 on EOF, so the
+    # pipeline reported success while nothing was ever transcribed — the
+    # worst kind of failure for a dictation tool. POSIX sh has no
+    # `pipefail`, so capture parks its status in a file we read afterwards.
+    st=$(mktemp) || exit 1
+    trap 'rm -f "$st"' EXIT
+    # ( capture ): GEIST_DIKTAT_CAPTURE is eval'd, so a command like `exit 17`
+    # would otherwise take the whole pipeline half down with it. And the
+    # status must be read via `||`, not a following line — `set -e` (line 15)
+    # kills the subshell on a non-zero capture before any next line runs.
+    # Nothing is written when capture succeeds; an empty file reads as 0.
+    rc=0
+    { ( capture ) || echo "$?" >"$st"; } | "$PREFIX/bin/diktat" "$MODEL" "$@" || rc=$?
+    cst=$(cat "$st" 2>/dev/null) || cst=0
+    # 141 is SIGPIPE: diktat exited first and closed the pipe, which is the
+    # normal way a run ends. Anything else means the mic died on its own.
+    if [ "${cst:-0}" != 0 ] && [ "$cst" != 141 ]; then
+        echo "geist-diktat: audio capture failed (exit $cst)" >&2
+        [ "$rc" = 0 ] && rc=1
+    fi
+    exit "$rc"
     ;;
 *)
     echo "usage: geist-diktat setup | run [rms-threshold]" >&2

--- a/scripts/sync-engine.sh
+++ b/scripts/sync-engine.sh
@@ -14,10 +14,20 @@ set -eu
 
 : "${GEIST_REPO:?}" "${GEIST_REF:?}" "${GEISTLIB:?}"
 
-if [ ! -d "$GEISTLIB/.git" ]; then
+# Never rm -rf a $GEISTLIB we did not create: the engine tree is where the
+# fetched model and audio tower land (gguf_artifacts/, audio_bench/ —
+# gigabytes), and the old code deleted it *before* a clone that can fail,
+# leaving neither. The submodule migration that needed that path is long
+# done; anything else in there is the user's, and `make distclean` is the
+# explicit way to drop it.
+if [ ! -e "$GEISTLIB" ]; then
     echo "engine: cloning $GEIST_REPO -> $GEISTLIB"
-    rm -rf "$GEISTLIB"
     git clone --quiet "$GEIST_REPO" "$GEISTLIB"
+elif [ ! -d "$GEISTLIB/.git" ]; then
+    echo "engine: $GEISTLIB exists but is not a git checkout." >&2
+    echo "engine: it may hold fetched models — move it aside yourself," >&2
+    echo "engine: or run 'make distclean', then build again." >&2
+    exit 1
 fi
 
 # Resolve the pin locally; only reach the network when the ref is unknown.

--- a/tests/test_engine_sync.py
+++ b/tests/test_engine_sync.py
@@ -1,0 +1,37 @@
+"""Regression coverage for the engine sync migration added during the audit."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+
+@unittest.skipUnless((ROOT/'scripts/sync-engine.sh').exists(),'sync script absent in pre-migration snapshot')
+class EngineSync(unittest.TestCase):
+    def test_existing_git_directory_needs_no_clone(self):
+        with tempfile.TemporaryDirectory() as d:
+            root=Path(d); engine=root/'engine'; (engine/'.git').mkdir(parents=True)
+            binary=root/'bin'; binary.mkdir()
+            git=binary/'git'
+            git.write_text('#!/bin/sh\ncase "$*" in *rev-parse*) echo pinned;; *) exit 99;; esac\n')
+            git.chmod(0o755)
+            p=subprocess.run(['sh',str(ROOT/'scripts/sync-engine.sh')],env=dict(os.environ,
+                PATH=str(binary)+os.pathsep+os.environ['PATH'],GEIST_REPO='unused',GEIST_REF='pinned',
+                GEISTLIB=str(engine)),capture_output=True,timeout=5)
+            self.assertEqual(p.returncode,0,p.stderr.decode())
+
+    def test_gitfile_checkout_survives_failed_clone(self):
+        with tempfile.TemporaryDirectory() as d:
+            root=Path(d); engine=root/'engine'; engine.mkdir()
+            (engine/'.git').write_text('gitdir: /old/submodule/metadata\n')
+            sentinel=engine/'local-model.gguf'; sentinel.write_bytes(b'local data must survive')
+            binary=root/'bin'; binary.mkdir()
+            git=binary/'git'; git.write_text('#!/bin/sh\nexit 128\n'); git.chmod(0o755)
+            p=subprocess.run(['sh',str(ROOT/'scripts/sync-engine.sh')],env=dict(os.environ,
+                PATH=str(binary)+os.pathsep+os.environ['PATH'],GEIST_REPO='offline',GEIST_REF='pinned',
+                GEISTLIB=str(engine)),capture_output=True,timeout=5)
+            self.assertNotEqual(p.returncode,0)
+            self.assertTrue(sentinel.exists(),'migration deletes local models before clone succeeds')
+
+if __name__=='__main__': unittest.main(verbosity=2)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,84 @@
+"""Offline installer tests. No real download, apt, sudo or external writes."""
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+
+class Installer(unittest.TestCase):
+    def setUp(self):
+        self.tmp=tempfile.TemporaryDirectory()
+        self.root=Path(self.tmp.name); self.bin=self.root/'bin'; self.bin.mkdir()
+        for name in ['mktemp','rm','mkdir','mv','cat','cut','sed','head','sh','sha256sum','shasum']:
+            path=shutil.which(name)
+            if path: (self.bin/name).symlink_to(path)
+        self.env=dict(os.environ,PATH=str(self.bin),HOME=str(self.root/'home'),
+            TMPDIR=str(self.root),TEST_OS='Darwin',TEST_ARCH='arm64',TEST_ROOT=str(self.root))
+        self.script('uname','case "$1" in -m) echo "$TEST_ARCH";; -s) echo "$TEST_OS";; esac')
+        self.script('curl', '''out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then shift; out=$1; fi
+  url=$1; shift
+done
+case "$url" in
+*/SHA256SUMS) cat "$TEST_ROOT/manifest" > "$out";;
+*) cat "$TEST_ROOT/asset" > "$out";;
+esac''')
+        self.script('tar','printf "tar\\n" >> "$TEST_ROOT/actions"')
+        self.script('id','echo 0')
+        self.asset('geist-diktat_macos-arm64.tar.gz')
+
+    def script(self,name,text):
+        p=self.bin/name; p.write_text('#!/bin/sh\n'+text+'\n'); p.chmod(0o755)
+    def asset(self,name,wrong=False):
+        data=b'test release asset'; (self.root/'asset').write_bytes(data)
+        sha='0'*64 if wrong else hashlib.sha256(data).hexdigest()
+        (self.root/'manifest').write_text(sha+'  '+name+'\n')
+    def tearDown(self): self.tmp.cleanup()
+    def run_install(self):
+        return subprocess.run(['sh',str(ROOT/'install.sh')],env=self.env,text=True,capture_output=True,timeout=10)
+    def actions(self):
+        p=self.root/'actions'; return p.read_text() if p.exists() else ''
+
+    def test_macos_tarball_verified(self):
+        p=self.run_install(); self.assertEqual(p.returncode,0,p.stderr)
+        self.assertIn('checksum ok',p.stdout); self.assertEqual(self.actions(),'tar\n')
+
+    def test_checksum_mismatch_blocks_install(self):
+        self.asset('geist-diktat_macos-arm64.tar.gz',wrong=True)
+        p=self.run_install(); self.assertNotEqual(p.returncode,0)
+        self.assertIn('checksum mismatch',p.stderr); self.assertEqual(self.actions(),'')
+
+    def test_unlisted_asset_blocks_install(self):
+        self.asset('another-asset')
+        p=self.run_install(); self.assertNotEqual(p.returncode,0); self.assertEqual(self.actions(),'')
+
+    def test_unsupported_architecture(self):
+        self.env['TEST_ARCH']='riscv64'
+        p=self.run_install(); self.assertNotEqual(p.returncode,0); self.assertEqual(self.actions(),'')
+
+    def test_intel_macos_rejected(self):
+        self.env['TEST_ARCH']='x86_64'
+        p=self.run_install(); self.assertNotEqual(p.returncode,0); self.assertIn('Apple Silicon',p.stderr)
+
+    def test_linux_deb_architectures(self):
+        self.script('apt-get','printf "apt %s\\n" "$*" >> "$TEST_ROOT/actions"')
+        self.env['TEST_OS']='Linux'
+        for arch,deb in [('aarch64','arm64'),('x86_64','amd64')]:
+            with self.subTest(arch=arch):
+                self.env['TEST_ARCH']=arch; self.asset('geist-diktat_'+deb+'.deb')
+                p=self.run_install(); self.assertEqual(p.returncode,0,p.stderr)
+                self.assertIn('geist-diktat_'+deb+'.deb',self.actions())
+
+    def test_extraction_failure_preserves_previous_install(self):
+        previous=self.root/'home/.local/geist-diktat'; previous.mkdir(parents=True)
+        (previous/'working').write_text('old working installation')
+        self.script('tar','exit 2')
+        p=self.run_install(); self.assertNotEqual(p.returncode,0)
+        self.assertTrue((previous/'working').exists(),'old installation deleted before extraction succeeds')
+
+if __name__=='__main__': unittest.main(verbosity=2)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,61 @@
+"""Launcher integration with isolated prefix/HOME and fake capture/binary."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT=Path(__file__).resolve().parents[1]
+
+class Launcher(unittest.TestCase):
+    def setUp(self):
+        self.tmp=tempfile.TemporaryDirectory(prefix="diktat quote ' ")
+        self.root=Path(self.tmp.name)
+        self.bin=self.root/'prefix/bin'; self.bin.mkdir(parents=True)
+        self.data=self.root/'data/geist-diktat'; self.data.mkdir(parents=True)
+        self.wrapper=self.bin/'geist-diktat'; shutil.copy(ROOT/'packaging/geist-diktat',self.wrapper)
+        self.wrapper.chmod(0o755)
+        self.stub=self.bin/'diktat'
+        self.stub.write_text('#!/bin/sh\ncat\nprintf "MODEL=%s\\nTOWER=%s\\nMEL=%s\\nRMS=%s\\n" "$1" "$GEIST_AUDIO_MODEL_PATH" "$GEIST_MEL_CONSTANTS_PATH" "$2" >&2\n')
+        self.stub.chmod(0o755)
+        self.env=dict(os.environ,HOME=str(self.root/'home'),XDG_DATA_HOME=str(self.root/'data'),
+            GEIST_DIKTAT_CAPTURE="printf 'Hallo Welt\\n'")
+        self.env.pop('GEIST_AUDIO_MODEL_PATH',None)
+        self.env.pop('GEIST_MEL_CONSTANTS_PATH',None)
+        (self.data/'gemma4-e2b-Q4_K_M.gguf').touch()
+
+    def tearDown(self): self.tmp.cleanup()
+    def call(self,*args):
+        return subprocess.run([str(self.wrapper),*args],env=self.env,capture_output=True,text=True,timeout=10)
+
+    def test_usage(self):
+        for args in [(),('wrong',)]:
+            p=self.call(*args); self.assertEqual(p.returncode,2); self.assertIn('usage:',p.stderr)
+
+    def test_missing_model(self):
+        (self.data/'gemma4-e2b-Q4_K_M.gguf').unlink()
+        p=self.call('run'); self.assertEqual(p.returncode,1); self.assertIn('model missing',p.stderr)
+
+    def test_prefix_data_quoting_and_capture(self):
+        p=self.call('run','420')
+        self.assertEqual(p.returncode,0,p.stderr)
+        self.assertEqual(p.stdout,'Hallo Welt\n')
+        self.assertIn('MODEL='+str(self.data/'gemma4-e2b-Q4_K_M.gguf'),p.stderr)
+        self.assertIn('TOWER='+str(self.data/'audio_tower.safetensors'),p.stderr)
+        self.assertIn('MEL='+str(self.root/'prefix/share/geist-diktat/mel_constants.bin'),p.stderr)
+        self.assertIn('RMS=420',p.stderr)
+
+    def test_environment_overrides(self):
+        self.env.update(GEIST_AUDIO_MODEL_PATH='/custom/tower',GEIST_MEL_CONSTANTS_PATH='/custom/mel')
+        p=self.call('run'); self.assertIn('TOWER=/custom/tower',p.stderr); self.assertIn('MEL=/custom/mel',p.stderr)
+
+    def test_capture_error_is_not_success(self):
+        self.env['GEIST_DIKTAT_CAPTURE']='exit 17'
+        p=self.call('run'); self.assertNotEqual(p.returncode,0,'capture failure hidden by pipeline exit status')
+
+    def test_decoder_failure_propagates(self):
+        self.stub.write_text('#!/bin/sh\ncat >/dev/null\nexit 19\n')
+        self.assertEqual(self.call('run').returncode,19)
+
+if __name__=='__main__': unittest.main(verbosity=2)


### PR DESCRIPTION
`make test-audit` — merged in #42 — pointed at tests that are not on
`main`. Running it locally: **22 of 53 fail, and they are real defects,
not broken tests.** This PR fixes the three that destroy data or hide
failure. The remaining 19 (six in the C core, two in the nvim plugin)
are untouched and need their own decision.

### 1. `scripts/sync-engine.sh` — deletes gigabytes before a clone that can fail

```sh
if [ ! -d "$GEISTLIB/.git" ]; then
    rm -rf "$GEISTLIB"          # <- model + audio tower live in here
    git clone --quiet "$GEIST_REPO" "$GEISTLIB"
fi
```

`.git` being a *file* (a gitdir pointer left by the old submodule
layout) fails the `-d` test, so the branch fires and takes
`gguf_artifacts/` and `audio_bench/` with it — then the clone fails on
an offline machine and there is nothing to restore from.

The migration this path existed for is long done, so it is removed
rather than made safe. An unexpected `$GEISTLIB` now fails loudly and
names `make distclean` as the deliberate way to drop it. Deleting a
directory we did not create is not this script's job.

### 2. `install.sh` — wipes the old install, then extracts

`rm -rf "$DEST"` followed by `tar -C "$DEST"`. Any tar failure — bad
download, full disk — leaves the user with no installation at all.
Unpack into `$TMP` first, swap only once tar has succeeded.

### 3. `packaging/geist-diktat` — a dead mic reported success

`capture | exec diktat` gives the pipeline the *decoder's* exit status.
A failed mic reaches diktat as EOF, diktat exits 0 on EOF, and
`geist-diktat run` returned success having transcribed nothing — the
worst failure mode a dictation tool has, because it looks like silence.

Three things the failing test alone did not reveal, each found by
running a real pipeline rather than by reading:

- `exec` inside `capture()` replaced the shell, so the status could not
  be observed at all. Dropped — one extra process, in exchange for a
  reportable failure.
- `set -e` (line 15) killed the pipeline subshell the moment capture
  returned non-zero, so a status line *after* capture never ran. The
  status has to be taken through `||`.
- SIGPIPE (141) is how a normal run ends — diktat exits first and closes
  the pipe. Reporting that as a mic failure would have made the fix
  worse than the bug.

Verified by hand in all three states: broken capture exits 1 with a
message, healthy capture exits 0 silently, and a decoder that exits
first still exits 0.

### Scope

Commits the three test files that prove these fixes, **not** the whole
audit suite — the other 19 failures are real and belong with their own
fixes, and committing them red would leave `main` permanently red.

Their harness gains `mv` on the sandboxed PATH. That list describes what
`install.sh` happens to call, not a minimal-system contract, and `mv` is
as POSIX-universal as the `rm` and `mkdir` already on it. No assertion
was changed — flagging it because editing a test to pass your own fix
deserves to be looked at.

With these three files present, `make test-audit` is green on `main`
instead of pointing at nothing.

### Verified

22 → 19 failures, exactly the three fixed and no regressions elsewhere.
Warning-free build, `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YTiU7S7KBHhDrypgXuKBt