### PR TITLE
fix: six defects in the dictation core

### DIFF
--- a/src/diktat.c
+++ b/src/diktat.c
@@ -55,26 +55,68 @@ static struct {
     const char   *instr;
 } cfg;
 
+/* Byte length of the UTF-8 sequence starting at c. A stray continuation
+ * byte reports 1 and is dropped as a control byte below. */
+static size_t utf8_len(unsigned char c) {
+    if (c < 0x80)
+        return 1;
+    if ((c & 0xE0) == 0xC0)
+        return 2;
+    if ((c & 0xF0) == 0xE0)
+        return 3;
+    if ((c & 0xF8) == 0xF0)
+        return 4;
+    return 1;
+}
+
 /* Append one decoded piece to line[], SentencePiece-normalized: U+2581 and
- * newlines become spaces, control bytes are dropped. */
+ * newlines become spaces, control bytes are dropped.
+ *
+ * Characters are copied whole or not at all. Byte-at-a-time copying let the
+ * REPLY_CAP cut land inside a multi-byte character, so a reply that happened
+ * to fill the buffer emitted invalid UTF-8 — and the old U+2581 test read
+ * p[1] and p[2] before checking that p[0] was not the last byte of the
+ * piece, which reads past the terminator on a piece ending in 0xE2. */
 static void append_piece(const char *t, char *line, size_t *len) {
-    for (const char *p = t; *p != '\0' && *len + 1 < REPLY_CAP; p++) {
-        if ((unsigned char) p[0] == 0xE2 && (unsigned char) p[1] == 0x96 &&
-            (unsigned char) p[2] == 0x81) {
+    for (const char *p = t; *p != '\0';) {
+        const unsigned char c   = (unsigned char) *p;
+        const size_t        seq = utf8_len(c);
+        /* A sequence the piece cuts short is not a character. */
+        if (strnlen(p, seq) < seq)
+            break;
+
+        if (seq == 3 && c == 0xE2 && (unsigned char) p[1] == 0x96 &&
+            (unsigned char) p[2] == 0x81) { /* U+2581, the word marker */
+            if (*len + 1 >= REPLY_CAP)
+                break;
             line[(*len)++] = ' ';
-            p += 2;
-        } else if (*p == '\n' || *p == '\r' || *p == '\t') {
-            line[(*len)++] = ' ';
-        } else if ((unsigned char) *p >= 0x20) {
-            line[(*len)++] = *p;
+            p += 3;
+        } else if (seq == 1) {
+            if (c == '\n' || c == '\r' || c == '\t') {
+                if (*len + 1 >= REPLY_CAP)
+                    break;
+                line[(*len)++] = ' ';
+            } else if (c >= 0x20) {
+                if (*len + 1 >= REPLY_CAP)
+                    break;
+                line[(*len)++] = (char) c;
+            }
+            p += 1;
+        } else {
+            if (*len + seq >= REPLY_CAP)
+                break;
+            memcpy(line + *len, p, seq);
+            *len += seq;
+            p += seq;
         }
     }
     line[*len] = '\0';
 }
 
 /* Audio already streamed into the session; finish the turn and emit the
- * transcript line. */
-static void transcribe_utterance(struct geist_session *sess) {
+ * transcript line. Returns 0, or 1 when the engine failed — a transcription
+ * that did not happen must not leave the process exiting 0. */
+static int transcribe_utterance(struct geist_session *sess) {
     char          suffix[PROMPT_CAP];
     geist_token_t toks[PROMPT_CAP];
     size_t        n = 0;
@@ -84,7 +126,7 @@ static void transcribe_utterance(struct geist_session *sess) {
     const size_t skip = (ok && n > 0 && toks[0] == cfg.bos) ? 1 : 0;
     if (!ok || geist_session_prefill_tokens(sess, n - skip, toks + skip) != GEIST_OK) {
         fprintf(stderr, "diktat: audio turn failed: %s\n", geist_session_errmsg(sess));
-        return;
+        return 1;
     }
 
     char          line[REPLY_CAP];
@@ -93,15 +135,17 @@ static void transcribe_utterance(struct geist_session *sess) {
     line[0]               = '\0';
     for (size_t i = 0; i < DECODE_CAP; i++) {
         geist_token_t tok;
-        if (geist_session_decode_step(sess, &tok) != GEIST_OK)
-            break;
+        if (geist_session_decode_step(sess, &tok) != GEIST_OK) {
+            fprintf(stderr, "diktat: decode failed: %s\n", geist_session_errmsg(sess));
+            return 1;
+        }
         if (tok == cfg.eos || tok == cfg.end_of_turn)
             break;
         /* A thought-channel reply is meta text, not dictation — drop the
          * whole utterance rather than typing it. */
         if (i == 0 && cfg.channel >= 0 && tok == cfg.channel) {
             fprintf(stderr, "diktat: model produced meta output, utterance dropped\n");
-            return;
+            return 0; /* dropped on purpose, not a failure */
         }
         /* #267 anti-loop: stop once the last 8 tokens are a period-1/2
          * cycle — keeps a hard clip from typing "big, big, big, ...". */
@@ -124,6 +168,7 @@ static void transcribe_utterance(struct geist_session *sess) {
         printf("%s\n", out);
         fflush(stdout);
     }
+    return 0;
 }
 
 int main(int argc, char **argv) {
@@ -133,13 +178,27 @@ int main(int argc, char **argv) {
                 argv[0]);
         return 2;
     }
-    const double rms_thr = argc > 2 ? atof(argv[2]) : 300.0;
+    /* atof() turned "abc" into 0.0 and accepted "nan", "-1" and "300junk" —
+     * a threshold of 0 opens the VAD on silence and never closes it. Reject
+     * before the model is loaded, so a typo costs no gigabytes. */
+    double rms_thr = 300.0;
+    if (argc > 2) {
+        char *end = nullptr;
+        rms_thr   = strtod(argv[2], &end);
+        if (end == argv[2] || *end != '\0' || !isfinite(rms_thr) || rms_thr <= 0.0) {
+            fprintf(stderr, "diktat: rms-threshold must be a positive number, got '%s'\n", argv[2]);
+            return 2;
+        }
+    }
     cfg.instr            = getenv("GEIST_DIKTAT_PROMPT");
     if (cfg.instr == nullptr)
         cfg.instr = "Transcribe this audio.";
 
+    /* cpu_scalar is the fallback of last resort, not the x86 backend: the
+     * list went neon -> scalar, so every x86 host quietly ran unaccelerated. */
     struct geist_backend *be = nullptr;
     if (geist_backend_create("cpu_neon", nullptr, nullptr, &be) != GEIST_OK &&
+        geist_backend_create("cpu_x86", nullptr, nullptr, &be) != GEIST_OK &&
         geist_backend_create("cpu_scalar", nullptr, nullptr, &be) != GEIST_OK) {
         fprintf(stderr, "backend create failed: %s\n", geist_last_create_error());
         return 1;
@@ -195,7 +254,26 @@ int main(int argc, char **argv) {
     int     loud = 0, quiet = 0;
     bool    in_speech = false;
 
-    while (fread(frame, sizeof(int16_t), FRAME, stdin) == FRAME) {
+    /* Every engine call below is checked: failures used to be logged and
+     * then ignored, so a session that had stopped working still exited 0
+     * and the pipeline downstream saw a clean run producing no text. */
+    int rc = 0;
+    for (;;) {
+        const size_t got = fread(frame, sizeof(int16_t), FRAME, stdin);
+        if (got < FRAME) {
+            /* Short read means EOF. The tail still counts: a final partial
+             * frame was dropped outright, and so was the whole last
+             * utterance when the mic closed while it was still open. */
+            if (in_speech && got > 0) {
+                if (geist_session_audio_push(sess, got, frame) != GEIST_OK) {
+                    fprintf(stderr, "audio_push failed: %s\n", geist_session_errmsg(sess));
+                    rc = 1;
+                } else {
+                    pushed += got;
+                }
+            }
+            break;
+        }
         const bool is_loud = frame_rms(frame) > rms_thr;
         if (!in_speech) {
             memcpy(pending[loud % OPEN_FRAMES], frame, sizeof frame);
@@ -205,19 +283,39 @@ int main(int argc, char **argv) {
             in_speech = true;
             quiet     = 0;
             pushed    = 0;
-            geist_session_reset(sess);
-            if (geist_session_audio_begin(sess) != GEIST_OK) {
-                fprintf(stderr, "audio_begin failed: %s\n", geist_session_errmsg(sess));
+            if (geist_session_reset(sess) != GEIST_OK) {
+                fprintf(stderr, "session_reset failed: %s\n", geist_session_errmsg(sess));
+                rc = 1;
                 break;
             }
-            for (int i = 0; i < OPEN_FRAMES - 1; i++) {
-                (void) geist_session_audio_push(sess, FRAME, pending[i]);
-                pushed += FRAME;
+            if (geist_session_audio_begin(sess) != GEIST_OK) {
+                fprintf(stderr, "audio_begin failed: %s\n", geist_session_errmsg(sess));
+                rc = 1;
+                break;
             }
+            for (int i = 0; i < OPEN_FRAMES - 1 && rc == 0; i++) {
+                if (geist_session_audio_push(sess, FRAME, pending[i]) != GEIST_OK) {
+                    fprintf(stderr, "audio_push failed: %s\n", geist_session_errmsg(sess));
+                    rc = 1;
+                } else {
+                    pushed += FRAME;
+                }
+            }
+            if (rc != 0)
+                break;
         }
-        if (pushed + FRAME <= MAX_UTT && geist_session_audio_push(sess, FRAME, frame) == GEIST_OK) {
+        if (pushed + FRAME <= MAX_UTT) {
+            if (geist_session_audio_push(sess, FRAME, frame) != GEIST_OK) {
+                fprintf(stderr, "audio_push failed: %s\n", geist_session_errmsg(sess));
+                rc = 1;
+                break;
+            }
             pushed += FRAME;
-            (void) geist_session_audio_poll(sess);
+            if (geist_session_audio_poll(sess) != GEIST_OK) {
+                fprintf(stderr, "audio_poll failed: %s\n", geist_session_errmsg(sess));
+                rc = 1;
+                break;
+            }
         }
         quiet = is_loud ? 0 : quiet + 1;
         if (quiet >= CLOSE_FRAMES || pushed + FRAME > MAX_UTT) {
@@ -226,19 +324,35 @@ int main(int argc, char **argv) {
             const size_t speech_len = pushed - (size_t) quiet * FRAME;
             if (geist_session_audio_end(sess) != GEIST_OK) {
                 fprintf(stderr, "audio_end failed: %s\n", geist_session_errmsg(sess));
-                continue;
+                rc = 1;
+                break;
             }
             if (speech_len >= MIN_UTT) {
                 fprintf(stderr, "diktat: [%.1f s]\n", (double) pushed / SR);
-                transcribe_utterance(sess);
-            } else {
-                geist_session_reset(sess);
+                if ((rc = transcribe_utterance(sess)) != 0)
+                    break;
+            } else if (geist_session_reset(sess) != GEIST_OK) {
+                fprintf(stderr, "session_reset failed: %s\n", geist_session_errmsg(sess));
+                rc = 1;
+                break;
             }
+        }
+    }
+
+    /* Still mid-utterance at EOF: close the turn and transcribe it. */
+    if (rc == 0 && in_speech) {
+        const size_t speech_len = pushed - (size_t) quiet * FRAME;
+        if (geist_session_audio_end(sess) != GEIST_OK) {
+            fprintf(stderr, "audio_end failed: %s\n", geist_session_errmsg(sess));
+            rc = 1;
+        } else if (speech_len >= MIN_UTT) {
+            fprintf(stderr, "diktat: [%.1f s]\n", (double) pushed / SR);
+            rc = transcribe_utterance(sess);
         }
     }
 
     geist_session_destroy(sess);
     geist_model_destroy(model);
     geist_backend_destroy(be);
-    return 0;
+    return rc;
 }

--- a/tests/core_stub.c
+++ b/tests/core_stub.c
@@ -1,0 +1,193 @@
+/* Execute the unmodified application against a deterministic fake geist API.
+ * This tests the actual VAD/lifecycle/output code, not speech recognition. */
+#define main diktat_main
+#include "../src/diktat.c"
+#undef main
+
+struct geist_backend {
+    int unused;
+};
+struct geist_model {
+    int unused;
+};
+struct geist_session {
+    int unused;
+};
+static struct geist_backend backend;
+static struct geist_model   model;
+static struct geist_session session;
+static int                  begins, ends, pushes, polls, decoded, resets, destroyed, loads;
+static int                  selected_x86;
+static size_t               samples;
+static int                  fail(const char *name) {
+    const char *s = getenv("STUB_FAIL");
+    return s && strcmp(s, name) == 0;
+}
+#define STATUS(name) (fail(name) ? GEIST_E_INVALID_ARG : GEIST_OK)
+const char *geist_last_create_error(void) {
+    return "injected failure";
+}
+const char *geist_session_errmsg(const struct geist_session *s) {
+    (void) s;
+    return "injected failure";
+}
+enum geist_status geist_backend_create(const char                      *name,
+                                       const struct geist_backend_opts *o,
+                                       const struct geist_allocator    *a,
+                                       struct geist_backend           **out) {
+    (void) o;
+    (void) a;
+    if (fail("x86-host") && strcmp(name, "cpu_neon") == 0)
+        return GEIST_E_INVALID_ARG;
+    selected_x86 = strcmp(name, "cpu_x86") == 0;
+    *out         = &backend;
+    return STATUS("backend");
+}
+void geist_backend_destroy(struct geist_backend *b) {
+    (void) b;
+    destroyed++;
+}
+enum geist_status
+geist_model_load(const char *p, struct geist_backend *b, struct geist_model **out) {
+    (void) p;
+    (void) b;
+    loads++;
+    *out = &model;
+    return STATUS("model");
+}
+void geist_model_destroy(struct geist_model *m) {
+    (void) m;
+    destroyed++;
+}
+unsigned geist_model_modalities(const struct geist_model *m) {
+    (void) m;
+    return fail("tower") ? 0 : GEIST_MOD_AUDIO;
+}
+enum geist_status geist_session_create(struct geist_model              *m,
+                                       struct geist_backend            *b,
+                                       const struct geist_session_opts *o,
+                                       struct geist_session           **out) {
+    (void) m;
+    (void) b;
+    (void) o;
+    *out = &session;
+    return STATUS("session");
+}
+void geist_session_destroy(struct geist_session *s) {
+    (void) s;
+    destroyed++;
+}
+enum geist_status geist_session_reset(struct geist_session *s) {
+    (void) s;
+    resets++;
+    decoded = 0;
+    return STATUS("reset");
+}
+geist_token_t geist_model_bos_token(const struct geist_model *m) {
+    (void) m;
+    return 1;
+}
+geist_token_t geist_model_eos_token(const struct geist_model *m) {
+    (void) m;
+    return 2;
+}
+geist_token_t geist_model_token_by_text(const struct geist_model *m, const char *t) {
+    (void) m;
+    return strcmp(t, "<turn|>") == 0 ? 3 : 4;
+}
+enum geist_status geist_session_tokenize(struct geist_session *s,
+                                         const char           *t,
+                                         size_t                cap,
+                                         geist_token_t         ids[static cap],
+                                         size_t               *n) {
+    (void) s;
+    (void) t;
+    ids[0] = 1;
+    ids[1] = 5;
+    *n     = 2;
+    return STATUS("tokenize");
+}
+enum geist_status
+geist_session_pin_prefix(struct geist_session *s, size_t n, const geist_token_t ids[static n]) {
+    (void) s;
+    (void) n;
+    (void) ids;
+    return STATUS("prefix");
+}
+enum geist_status
+geist_session_prefill_tokens(struct geist_session *s, size_t n, const geist_token_t ids[static n]) {
+    (void) s;
+    (void) n;
+    (void) ids;
+    return STATUS("prefill");
+}
+enum geist_status geist_session_audio_begin(struct geist_session *s) {
+    (void) s;
+    begins++;
+    return STATUS("begin");
+}
+enum geist_status
+geist_session_audio_push(struct geist_session *s, size_t n, const int16_t p[static n]) {
+    (void) s;
+    (void) p;
+    pushes++;
+    if (fail("push"))
+        return GEIST_E_INVALID_ARG;
+    samples += n;
+    return GEIST_OK;
+}
+enum geist_status geist_session_audio_poll(struct geist_session *s) {
+    (void) s;
+    polls++;
+    return STATUS("poll");
+}
+enum geist_status geist_session_audio_end(struct geist_session *s) {
+    (void) s;
+    ends++;
+    return STATUS("end");
+}
+enum geist_status geist_session_decode_step(struct geist_session *s, geist_token_t *out) {
+    (void) s;
+    decoded++;
+    if (fail("meta"))
+        *out = 4;
+    else if (fail("loop"))
+        *out = 5;
+    else if (fail("cycle2"))
+        *out = 5 + decoded % 2;
+    else if (fail("cap"))
+        *out = 5 + decoded % 3;
+    else
+        *out = decoded == 1 ? 5 : 2;
+    return STATUS("decode");
+}
+const char *geist_session_token_to_str(struct geist_session *s, geist_token_t t) {
+    (void) s;
+    (void) t;
+    const char *piece = getenv("STUB_PIECE");
+    return piece ? piece : "▁Hallo\nWelt\tGrüße\001!";
+}
+int main(int argc, char **argv) {
+    if (argc > 1 && strcmp(argv[1], "--append-boundary") == 0) {
+        char   line[REPLY_CAP];
+        size_t n           = 0;
+        char   truncated[] = {(char) 0xe2, 0};
+        append_piece(truncated, line, &n);
+        return 0;
+    }
+    int rc = diktat_main(argc, argv);
+    fprintf(stderr,
+            "STATS begins=%d ends=%d pushes=%d polls=%d samples=%zu decoded=%d resets=%d "
+            "destroyed=%d loads=%d selected_x86=%d\n",
+            begins,
+            ends,
+            pushes,
+            polls,
+            samples,
+            decoded,
+            resets,
+            destroyed,
+            loads,
+            selected_x86);
+    return rc;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,178 @@
+"""Application contract tests; failures describe defects in the audited revision."""
+import os
+from pathlib import Path
+import re
+import shlex
+import struct
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def pcm(loud=25, quiet=40, amplitude=1000):
+    return struct.pack('<h', amplitude) * 320 * loud + bytes(640 * quiet)
+
+class Core(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.binary = str(Path(cls.tmp.name) / 'core-stub')
+        coverage = os.getenv('GEIST_TEST_COVERAGE_DIR')
+        if coverage:
+            Path(coverage).mkdir(parents=True, exist_ok=True)
+            cls.binary = str(Path(coverage).resolve() / 'core-stub')
+        cmd = shlex.split(os.getenv('CC', 'cc')) + ['-std=c2x', '-O1', '-g',
+            '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+            '-I' + str(ROOT / 'geistlib/include'), str(ROOT / 'tests/core_stub.c'),
+            '-lm', '-o', cls.binary]
+        if coverage:
+            cmd += ['-fprofile-instr-generate', '-fcoverage-mapping']
+        subprocess.run(cmd, check=True, capture_output=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def run_core(self, data=b'', args=('model.gguf',), fail='', piece=None):
+        env = dict(os.environ, STUB_FAIL=fail, ASAN_OPTIONS='detect_leaks=0')
+        if piece is not None:
+            env['STUB_PIECE'] = piece
+        p = subprocess.run([self.binary, *args], input=data, capture_output=True, env=env, timeout=10)
+        stats = dict((k, int(v)) for k, v in re.findall(r'(\w+)=(\d+)', p.stderr.decode(errors='replace')))
+        return p, stats
+
+    def test_usage(self):
+        p, s = self.run_core(args=())
+        self.assertEqual(p.returncode, 2)
+        self.assertIn(b'usage:', p.stderr)
+        self.assertEqual(s['loads'], 0)
+
+    def test_initialization_failures_cleanup(self):
+        for failure, destroyed in [('backend',0), ('model',1), ('tower',2), ('session',2), ('tokenize',3), ('prefix',3)]:
+            with self.subTest(failure=failure):
+                p,s=self.run_core(fail=failure)
+                self.assertEqual(p.returncode, 1)
+                self.assertEqual(s['destroyed'], destroyed)
+                self.assertEqual(p.stdout, b'')
+
+    def test_silence(self):
+        p,s=self.run_core(bytes(640*100))
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(s['begins'],0)
+        self.assertEqual(p.stdout,b'')
+
+    def test_x86_host_selects_available_accelerated_backend(self):
+        p,s=self.run_core(fail='x86-host')
+        self.assertEqual(p.returncode,0)
+        self.assertEqual(s['selected_x86'],1,'x86 host falls back to scalar despite available cpu_x86')
+
+    def test_open_requires_three_consecutive_frames(self):
+        p,s=self.run_core(pcm(2,1)*10)
+        self.assertEqual(s['begins'],0)
+
+    def test_threshold_is_strict(self):
+        p,s=self.run_core(pcm(amplitude=300))
+        self.assertEqual(s['begins'],0)
+
+    def test_negative_samples_rms(self):
+        p,s=self.run_core(pcm(amplitude=-1000))
+        self.assertEqual(s['ends'],1)
+
+    def test_first_three_frames_preserved(self):
+        p,s=self.run_core(pcm())
+        self.assertEqual(s['samples'],65*320)
+
+    def test_short_utterance_dropped(self):
+        p,s=self.run_core(pcm(24))
+        self.assertEqual(s['ends'],1)
+        self.assertEqual(p.stdout,b'')
+
+    def test_minimum_utterance_and_normalization(self):
+        p,s=self.run_core(pcm())
+        self.assertEqual(p.stdout,'Hallo Welt Grüße!\n'.encode())
+
+    def test_multiple_utterances(self):
+        p,s=self.run_core(pcm()*3)
+        self.assertEqual(s['ends'],3)
+        self.assertEqual(len(p.stdout.splitlines()),3)
+
+    def test_thirty_minutes_use_one_model_and_preserve_all_turns(self):
+        # 1400 * 1.3 s = 30 min 20 s of PCM. Unpaced, fake recognition:
+        # lifecycle/segmentation stress only, not a real ASR conversation test.
+        p,s=self.run_core(pcm()*1400)
+        self.assertEqual(p.returncode,0)
+        self.assertEqual((s['loads'],s['begins'],s['ends']),(1,1400,1400))
+        self.assertEqual(s['samples'],1400*65*320)
+        self.assertEqual(len(p.stdout.splitlines()),1400)
+        self.assertEqual(s['destroyed'],3)
+
+    def test_full_scale_pcm_does_not_overflow_rms(self):
+        for amplitude in (-32768,32767):
+            with self.subTest(amplitude=amplitude):
+                p,s=self.run_core(pcm(amplitude=amplitude))
+                self.assertEqual(p.returncode,0)
+                self.assertEqual(s['ends'],1)
+
+    def test_short_pause_keeps_one_utterance(self):
+        p,s=self.run_core(pcm(25,39)+pcm())
+        self.assertEqual(s['ends'],1)
+
+    def test_maximum_segment(self):
+        p,s=self.run_core(pcm(1400,0))
+        self.assertEqual(s['samples'],28*16000)
+        self.assertEqual(s['ends'],1)
+
+    def test_eof_flushes_speech(self):
+        p,s=self.run_core(pcm(25,0))
+        self.assertEqual(s['ends'],1, 'EOF loses the final utterance')
+        self.assertTrue(p.stdout)
+
+    def test_partial_final_frame_preserved(self):
+        p,s=self.run_core(pcm(25,0)+bytes(100))
+        self.assertEqual(s['samples'],25*320+50)
+
+    def test_invalid_threshold_rejected(self):
+        for threshold in ['abc','nan','inf','-1','0','300junk']:
+            with self.subTest(threshold=threshold):
+                p,s=self.run_core(args=('model.gguf',threshold))
+                self.assertEqual(p.returncode,2)
+                self.assertEqual(s['loads'],0)
+
+    def test_stream_errors_propagate(self):
+        for failure in ['reset','begin','push','poll','end','prefill','decode']:
+            with self.subTest(failure=failure):
+                p,s=self.run_core(pcm(),fail=failure)
+                self.assertNotEqual(p.returncode,0, 'runtime failure reported as success')
+
+    def test_meta_output_dropped(self):
+        p,s=self.run_core(pcm(),fail='meta')
+        self.assertEqual(p.stdout,b'')
+        self.assertIn(b'meta output',p.stderr)
+
+    def test_repetition_guard(self):
+        for failure in ['loop','cycle2']:
+            p,s=self.run_core(pcm(),fail=failure)
+            self.assertEqual(s['decoded'],8)
+
+    def test_decode_cap(self):
+        p,s=self.run_core(pcm(),fail='cap')
+        self.assertEqual(s['decoded'],400)
+
+    def test_output_cap(self):
+        p,s=self.run_core(pcm(),piece='x'*8000)
+        self.assertEqual(len(p.stdout),4096)
+
+    def test_unicode_boundary_sanitized(self):
+        p,s=self.run_core(pcm(),piece='a'*4094+'ü')
+        try:
+            p.stdout.decode('utf-8')
+        except UnicodeDecodeError as error:
+            self.fail('reply cap splits a UTF-8 character: '+str(error))
+
+    def test_truncated_piece_memory_safety(self):
+        p,s=self.run_core(args=('--append-boundary',))
+        self.assertEqual(p.returncode,0,p.stderr.decode(errors='replace'))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The audit suite's core contracts, run against the real `src/diktat.c`
under ASan/UBSan. All six sit in the streaming path — the place where a
wrong answer is indistinguishable from silence, which is why none of
them had been noticed.

### Lost audio

- **EOF mid-utterance dropped the whole utterance.** `while (fread(...)
  == FRAME)` exits and nothing closes the open turn. The last thing you
  say before the mic closes is exactly what a dictation tool may not
  lose. The turn is now closed and transcribed after the loop.
- **A final partial frame went with it.** A short read means EOF, so
  push what arrived instead of discarding it.

### Failures reported as success

`reset`, `audio_begin`, `audio_push`, `audio_poll`, `audio_end`,
`prefill` and `decode` failures were logged to stderr and then ignored —
two of them were even explicitly `(void)`-cast. The process still exited
0, so a session that had stopped working looked, to whatever consumes
the transcript downstream, like a clean run that produced no text.

Every call is checked now and `transcribe_utterance` returns a status.
Meta output stays a deliberate drop rather than a failure.

### Input and output

- **`atof(argv[2])`** turned `"abc"` into `0.0` and accepted `"nan"`,
  `"-1"` and `"300junk"`. A threshold of 0 opens the VAD on silence and
  never closes it. Now `strtod` with a full-string check, rejected with
  exit 2 *before* the model loads — a typo should not cost a 3.7 GB
  download first.
- **`append_piece` read past the terminator.** It tested `p[1]` and
  `p[2]` for the U+2581 marker before establishing that `p[0]` was not
  the piece's last byte; a piece ending in `0xE2` reads out of bounds
  (ASan catches it). It also copied byte-at-a-time against `REPLY_CAP`,
  so a reply that filled the buffer could be cut *inside* a multi-byte
  character and emit invalid UTF-8 on stdout. Characters are copied
  whole or not at all now.
- **`cpu_x86` was never tried.** The list went `cpu_neon` →
  `cpu_scalar`, so every x86 host quietly ran unaccelerated on a model
  that needs all the help it can get. `cpu_x86` goes in between; scalar
  stays the fallback of last resort.

### Tests

Commits `tests/test_core.py` and `tests/core_stub.c`. The stub
`#include`s the real `src/diktat.c` and replaces only the geist API, so
these exercise the shipped VAD, lifecycle and output code — segmentation
and lifecycle, explicitly not speech accuracy.

25/25 core contracts pass under ASan/UBSan. The audit suite as a whole
goes from 19 failures to 2, both remaining ones in the nvim plugin.
Warning-free build, `make test` green, and the real binary verified by
hand: `diktat model.gguf abc` and `... 0` now exit 2 with a message,
`... 420` proceeds to the model load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YTiU7S7KBHhDrypgXuKBt