### PR TITLE
feat: attest build provenance for every release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,13 @@ jobs:
     needs: [artifacts, linux-tarball, macos-tarball]
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/')
+    # Scoped to this job: it is the only one that signs, so it is the only one
+    # that gets a token which can. id-token mints the OIDC identity the
+    # attestation is bound to; attestations writes it to the public log.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -176,6 +183,18 @@ jobs:
           done
       - name: SHA256SUMS (install.sh verifies every asset against it)
         run: sha256sum geist-diktat_*.deb geist-diktat_*.tar.gz > SHA256SUMS
+      # SHA256SUMS says the bytes are intact. It cannot say where they came
+      # from — anyone can publish a file and a matching checksum. This binds
+      # each artifact to this repository, this workflow and this commit, in a
+      # public transparency log, with no signing key to hold or rotate.
+      #   gh attestation verify geist-diktat_amd64.deb --repo geisten/geist-diktat
+      - name: attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            geist-diktat_*.deb
+            geist-diktat_*.tar.gz
+            SHA256SUMS
       - name: create release with all artifacts
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ app (GTK, Qt, Electron, VTE terminals) receives it.
 Prefer to wire the typing yourself? `geist-diktat run` prints transcript
 lines on stdout; compose them as in the snippet above.
 
+## Verifying a download
+
+Every release ships `SHA256SUMS`, and `install.sh` checks each asset against
+it automatically — that catches a truncated or swapped file.
+
+To also confirm *where* a file came from, verify its build provenance. Each
+artifact is bound to this repository, its release workflow and the exact
+commit, in a public transparency log:
+
+```sh
+gh attestation verify geist-diktat_amd64.deb --repo geisten/geist-diktat
+```
+
+The tarballs are reproducible: the same commit produces byte-identical
+archives, so the checksum can be recomputed from source rather than trusted.
+
 ## Build from source
 
 ```sh

--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,13 @@ trap 'rm -rf "$TMP"' EXIT
 # compromised release. v0.1.2 predates that manifest, so keep its independently
 # verified hashes as a narrow migration path. Any other manifest-less release
 # still fails closed because its assets cannot match these pins.
-# ponytail: signature verification (gh attestation / minisign) is the upgrade
-# path once releases are signed.
+#
+# Releases from v0.1.3 on also carry build provenance, which answers the
+# question a checksum cannot — where the bytes came from:
+#   gh attestation verify <file> --repo geisten/geist-diktat
+# Deliberately not run here: it needs gh installed and authenticated, and a
+# check that cannot tell "could not verify" from "verification failed" is
+# worse than none. Whoever wants the stronger guarantee runs one command.
 if ! curl -fL --retry 3 -o "$TMP/SHA256SUMS" "$BASE/SHA256SUMS"; then
     echo "geist-diktat: release manifest unavailable; trying pinned v0.1.2 hashes" >&2
     cat > "$TMP/SHA256SUMS" <<'EOF'


### PR DESCRIPTION
`SHA256SUMS` beweist, dass die Bytes unversehrt sind. Es beweist nicht, **woher** sie kommen — jeder kann eine Datei samt passendem Manifest veröffentlichen, und `install.sh` würde beides anstandslos akzeptieren.

Mit den reproduzierbaren Tarballs aus der letzten Änderung lassen sich die Bytes gegen den Quellcode nachrechnen. Provenance ist die andere Hälfte: Sie bindet jedes Artefakt an dieses Repository, diesen Workflow und diesen Commit — in einem öffentlichen Transparency-Log.

## Umsetzung

`actions/attest-build-provenance@v2`, also **kein Signaturschlüssel**, den jemand halten, rotieren oder verlieren kann. Die nötigen Rechte sind auf den `publish`-Job beschränkt statt workflow-weit gesetzt:

```yaml
permissions:
  contents: write
  id-token: write
  attestations: write
```

Nur dieser Job signiert, also bekommt auch nur er ein Token, das das kann.

Der Schritt läuft **nach** `SHA256SUMS` und **vor** `gh release create` — so erreicht kein Artefakt einen Nutzer unattestiert.

Abgedeckt: `geist-diktat_*.deb`, `geist-diktat_*.tar.gz` und `SHA256SUMS` selbst.

## Warum `install.sh` die Prüfung nicht ausführt

Sie bräuchte ein installiertes und authentifiziertes `gh`. Eine Prüfung, die „konnte nicht verifizieren" nicht von „Verifikation fehlgeschlagen" unterscheiden kann, ist schlechter als keine — sie erzieht dazu, sie zu ignorieren.

Stattdessen ist der Befehl dokumentiert, in `install.sh` und in einem neuen README-Abschnitt:

```sh
gh attestation verify geist-diktat_amd64.deb --repo geisten/geist-diktat
```

Der `ponytail:`-Kommentar, der Provenance als Upgrade-Pfad markierte, ist damit eingelöst und entfernt.

## Verifikation

**Vor einem Tag nicht testbar** — Attestation läuft ausschließlich im Release-Workflow, und den löst nur ein `v*`-Tag aus. Das YAML parst, die Action ist wie dokumentiert eingebunden, die Rechte sind gesetzt. Der erste getaggte Release ist der Beweis; danach lässt sich jedes Asset mit dem Befehl oben gegenprüfen.

Die CI dieses PRs prüft, dass nichts anderes gebrochen ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)