### PR TITLE
docs: provenance lands in v0.2.0, not v0.1.3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ trap 'rm -rf "$TMP"' EXIT
 # verified hashes as a narrow migration path. Any other manifest-less release
 # still fails closed because its assets cannot match these pins.
 #
-# Releases from v0.1.3 on also carry build provenance, which answers the
+# Releases from v0.2.0 on also carry build provenance, which answers the
 # question a checksum cannot — where the bytes came from:
 #   gh attestation verify <file> --repo geisten/geist-diktat
 # Deliberately not run here: it needs gh installed and authenticated, and a


### PR DESCRIPTION
Einzeiler vor dem Tag. Der Kommentar in `install.sh` nannte `v0.1.3` als erste Version mit Build-Provenance — das war geschrieben, bevor die Versionsnummer feststand.

Der Release ist ein **Minor**-Bump, kein Patch:

- **macOS** ist eine neue Plattform
- `geist-diktat toggle | start | stop | status` sind entfernt — wer den Toggle an einen Hotkey gebunden hatte, verliert ihn
- das Build-Interface hat sich geändert: Submodul → `GEIST_REF`

Ohne diese Korrektur verwiese der Release auf eine Version, die es nie geben wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)