### PR TITLE
build: default GEMM_PROVIDER to native, where the ?= actually takes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: deps
-        run: sudo apt-get update -q && sudo apt-get install -y -q libopenblas-dev gcc-14
+        run: sudo apt-get update -q && sudo apt-get install -y -q gcc-14
       - name: build
         run: make CC=gcc-14 TARGET=linux
       - name: smoke test (fixture-gated half skips without the 3.7 GB model)

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,22 @@ ifneq ($(ENGINE),ok)
 $(error engine sync failed — see the messages above)
 endif
 
+# Before the target include, not after. Every mk/target-*.mk sets its own
+# GEMM_PROVIDER ?= (openblas on linux and pi5, accelerate on mac), and ?= only
+# takes when the variable is still unset — so ours, sitting after the include,
+# never applied. A plain `make` on Linux therefore demanded OpenBLAS while
+# every artifact we ship is built GEMM_PROVIDER=native, and a CI job without
+# libopenblas-dev died on it.
+#
+# Not auto-detected. Probing for -lopenblas and falling back would make the
+# GEMM backend depend on what happens to be installed on the builder — the
+# same commit producing a differently-linked binary on two machines, silently.
+# The tarballs are reproducible precisely so that cannot happen.
+# `make GEMM_PROVIDER=openblas` opts in explicitly.
+GEMM_PROVIDER ?= native
+
 TARGET ?= $(shell $(GEISTLIB)/mk/detect-target.sh)
 include $(GEISTLIB)/mk/target-$(TARGET).mk
-
-GEMM_PROVIDER ?= native
 include $(GEISTLIB)/mk/gemm-$(GEMM_PROVIDER).mk
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,19 @@ ibus-engine-geist-diktat-test: ibus/engine.c
 ibus-test-client: ibus/test_client.c
 	$(CC) $(IBUS_CFLAGS) -o $@ $< $(IBUS_LIBS)
 
+# GEMM_PROVIDER is forwarded, and that is load-bearing: a variable set in this
+# file is not inherited by a sub-make (only a command-line one is), so the
+# engine would re-pick its own target default and compile the archive against
+# OpenBLAS while diktat links without it — an undefined-reference link error
+# on cblas_sgemv. It only ever worked because every caller happened to pass
+# GEMM_PROVIDER on the command line.
+#
 # Always delegate: the submodule's own make is incremental and cheap,
 # and a plain file target went stale on submodule bumps (the lib exists
 # but is outdated — measured: a deaf binary after the #277 pin bump).
 $(LIB): FORCE
-	$(MAKE) -C $(GEISTLIB) lib TARGET=$(TARGET) MODE=$(MODE)
+	$(MAKE) -C $(GEISTLIB) lib TARGET=$(TARGET) MODE=$(MODE) \
+		GEMM_PROVIDER=$(GEMM_PROVIDER)
 
 FORCE:
 


### PR DESCRIPTION
## Der Fehler

```make
TARGET ?= $(shell .../detect-target.sh)
include $(GEISTLIB)/mk/target-$(TARGET).mk

GEMM_PROVIDER ?= native          # <- kam zu spät
include $(GEISTLIB)/mk/gemm-$(GEMM_PROVIDER).mk
```

Jede `mk/target-*.mk` setzt ihren eigenen Provider — `openblas` auf linux und pi5, `accelerate` auf mac. `?=` weist nur zu, solange die Variable **unbelegt** ist. Unsere Zeile stand danach und hat deshalb **nie** gegriffen.

Ein schlichtes `make` auf Linux verlangte damit seit jeher OpenBLAS. Der neue `contracts`-Job hat kein `libopenblas-dev` und starb daran:

```
gemm-openblas.mk:30: *** OpenBLAS not found (tried: -lopenblas).
```

## Die interessantere Abweichung dahinter

**Jedes ausgelieferte Artefakt** wird mit `GEMM_PROVIDER=native` gebaut — `.deb`, beide Linux-Tarballs, der macOS-Tarball. Ein Quell-Build linkte also einen GEMM-Pfad, den kein Release verwendet.

Nach dieser Änderung stimmen beide überein. Der pi5-Job kommentiert seinen fehlenden Override mit *„exactly what a user gets"* — das wird damit wahr statt ungefähr wahr. Nebenwirkung: Seine Performance-Zahlen verschieben sich, weil er jetzt denselben Pfad misst, den Nutzer bekommen.

## Warum keine Auto-Erkennung

Die Frage lag nahe: auf `-lopenblas` probieren und sonst auf native zurückfallen. Ich rate ab.

Ein solcher Probe macht das GEMM-Backend davon abhängig, **was zufällig auf der Build-Maschine installiert ist** — derselbe Commit ergäbe auf zwei Rechnern still unterschiedlich gelinkte Binaries. Das ist genau das Gegenteil der Reproduzierbarkeit, die die Tarballs gerade bekommen haben, und es wäre nicht einmal sichtbar.

`make GEMM_PROVIDER=openblas` bleibt der explizite Weg hinein.

## `libopenblas-dev` fliegt aus `ci.yml`

Statt es in `quality-audit.yml` **zu ergänzen**, entfällt es: Nach dieser Änderung baut kein Job mehr gegen OpenBLAS. Ein Paket, das für einen Pfad installiert wird, den niemand nimmt, ist Ballast.

Damit wird auch `contracts` grün, ohne dass irgendwo ein Paket dazukommt.

## Verifikation

Auf macOS in beide Richtungen geprüft:

| | Ergebnis |
|---|---|
| Default | `GEIST_GEMM_NATIVE` ✓ |
| `GEMM_PROVIDER=accelerate` | Accelerate-Pfad ✓ |
| Build + `tests/smoke.sh` | grün |

🤖 Generated with [Claude Code](https://claude.com/claude-code)